### PR TITLE
Feature/knot point view

### DIFF
--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -20,6 +20,22 @@ function Base.getindex(slice::KnotPoint, symb::Symbol)
     end
 end
 
+function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
+    if symb in fieldnames(KnotPoint)
+        setfield!(slice, symb, val)
+    else
+        update!(slice, symb, val)
+    end
+end
+
+
+function Base.update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
+    @assert symb in slice.names
+    @assert size(data, 1) == (slice.components[symb].stop - slice.components[symb].start + 1)
+
+    Base.getproperty(slice, symb)[:] = data
+    return nothing
+end
 
 
 end

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -11,12 +11,12 @@ function Base.getproperty(slice::KnotPoint, symb::Symbol)
     end
 end
 
-function Base.getindex(slice::KnotPoint, symb::Symbol)
+function Base.getindex(slice::KnotPoint, symb::Symbol) # is this method redundant? i.e. should we just dispatch to getproperty?
     if symb in fieldnames(KnotPoint)
         return getfield(slice, symb)
     else
         indices = slice.components[symb]
-        return slice.data[indices]
+        return view(slice.data, indices)
     end
 end
 
@@ -26,6 +26,10 @@ function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     else
         update!(slice, symb, val)
     end
+end
+
+function Base.setindex!(slice::KnotPoint, symb::Symbol, val::Any)
+    setproperty!(slice, symb, val)
 end
 
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -7,7 +7,7 @@ function Base.getproperty(slice::KnotPoint, symb::Symbol)
         return getfield(slice, symb)
     else
         indices = slice.components[symb]
-        return slice.data[indices]
+        return view(slice.data, indices)
     end
 end
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -22,14 +22,14 @@ end
 
 function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     if symb in fieldnames(KnotPoint)
-        setfield!(slice, symb, val)
+        setfield!(slice, symb, val) # will throw error since KnotPoint is an immutable struct
     else
         update!(slice, symb, val)
     end
 end
 
 
-function Base.update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
+function update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
     @assert symb in slice.names
     @assert size(data, 1) == (slice.components[symb].stop - slice.components[symb].start + 1)
 

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -35,7 +35,7 @@ function StructKnotPoint.KnotPoint(
 )
     @assert 1 ≤ t ≤ Z.T
     timestep = get_timesteps(Z)[t]
-    return KnotPoint(t, Z.data[:, t], timestep, Z.components, Z.names, Z.control_names)
+    return KnotPoint(t, view(Z.data, :, t), timestep, Z.components, Z.names, Z.control_names)
 end
 
 """


### PR DESCRIPTION
The changes herein alter the constructor of `KnotPoint` such that a `KnotPoint`'s data field is represented by a view of the parent `NamedTrajectory`'s data field. Also included is a new `update!(::KnotPoint, ::Symbol, ::AbstractVector{Float64})` method analogous to `update!(::NamedTrajectory, ::Symbol, ::AbstractMatrix{Float64})`, along with perfunctory `Base.set{property,index}!(::KnotPoint, ::Symbol, ::Any)` methods analogous to `Base.set{property,index}!(::NamedTrajectory, ::Symbol, ::Any)`.

The most noteworthy changes are as follows:
- A trajectory's knot point data is synchronized with that of the parent trajectory:
```
idx = 1
symb = :x
kp = traj[idx]
@assert traj.datavec[((idx - 1) * traj.dim) .+ getproperty(traj.components, symb)] == kp.a
traj.datavec[((idx - 1) * traj.dim) .+ getproperty(traj.components, symb)] = rand(getproperty(traj.dims, symb))
@assert traj.datavec[((idx - 1) * traj.dim) .+ getproperty(traj.components, symb)] == kp.a # still passes after directly modifying NamedTrajectory
kp.a = rand(getproperty(traj.dims, symb)) # this fails prior to changes made in this PR
@assert traj.datavec[((idx - 1) * traj.dim) .+ getproperty(traj.components, symb)] == kp.a # still passes after directly modifying KnotPoint
```
- A trajectory's knot point may be written to like so:
```
kp = traj[idx]
kp.x = zeros(kp.components.x.stop - kp.components.x.start + 1) # this fails prior to changes made in this PR
# without relying implicitly on update! via setproperty!, the same can be accomplished with getproperty like so:
kp.x[:] = zeros(kp.components.x.stop - kp.components.x.start + 1) # this fails prior to changes made in this PR
```