### PR TITLE
Feature/knot point and component view

### DIFF
--- a/docs/literate/man/modifying.jl
+++ b/docs/literate/man/modifying.jl
@@ -125,8 +125,6 @@ idx = 2 # u
 println([((k - 1) * traj.dim) .+ getproperty(traj.components, traj.names[idx]) for k in 1:traj.T])
 
 
-# TODO: etc.
-
 # ### Writability
 
 # #### Views and Backing Stores

--- a/docs/src/lib.md
+++ b/docs/src/lib.md
@@ -4,8 +4,7 @@
 ## NamedTrajectory methods
 ```@autodocs
 Modules = [
-    NamedTrajectories.MethodsNamedTrajectory,
-    NamedTrajectories.MethodsKnotPoint
+    NamedTrajectories.MethodsNamedTrajectory
 ]
 ```
 
@@ -19,8 +18,7 @@ Modules = [
 ## Struct Methods
 ```@autodocs
 Modules = [
-    StructNamedTrajectory,
-    StructKnotPoint
+    StructNamedTrajectory
 ]
 ```
 

--- a/docs/src/lib.md
+++ b/docs/src/lib.md
@@ -4,7 +4,8 @@
 ## NamedTrajectory methods
 ```@autodocs
 Modules = [
-    NamedTrajectories.MethodsNamedTrajectory
+    NamedTrajectories.MethodsNamedTrajectory,
+    NamedTrajectories.MethodsKnotPoint
 ]
 ```
 
@@ -18,7 +19,8 @@ Modules = [
 ## Struct Methods
 ```@autodocs
 Modules = [
-    StructNamedTrajectory
+    StructNamedTrajectory,
+    StructKnotPoint
 ]
 ```
 

--- a/docs/src/lib.md
+++ b/docs/src/lib.md
@@ -4,7 +4,8 @@
 ## NamedTrajectory methods
 ```@autodocs
 Modules = [
-    NamedTrajectories.MethodsNamedTrajectory
+    NamedTrajectories.MethodsNamedTrajectory,
+    NamedTrajectories.MethodsKnotPoint
 ]
 ```
 
@@ -18,7 +19,8 @@ Modules = [
 ## Struct Methods
 ```@autodocs
 Modules = [
-    StructNamedTrajectory
+    StructNamedTrajectory,
+    StructKnotPoint
 ]
 ```
 
@@ -27,5 +29,4 @@ Modules = [
 Modules = [
     Utils
 ]
-``` 
-
+```

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -20,6 +20,22 @@ function Base.getindex(slice::KnotPoint, symb::Symbol)
     end
 end
 
+function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
+    if symb in fieldnames(KnotPoint)
+        setfield!(slice, symb, val)
+    else
+        update!(slice, symb, val)
+    end
+end
+
+
+function Base.update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
+    @assert symb in slice.names
+    @assert size(data, 1) == (slice.components[symb].stop - slice.components[symb].start + 1)
+
+    Base.getproperty(slice, symb)[:] = data
+    return nothing
+end
 
 
 end

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -11,12 +11,12 @@ function Base.getproperty(slice::KnotPoint, symb::Symbol)
     end
 end
 
-function Base.getindex(slice::KnotPoint, symb::Symbol)
+function Base.getindex(slice::KnotPoint, symb::Symbol) # is this method redundant? i.e. should we just dispatch to getproperty?
     if symb in fieldnames(KnotPoint)
         return getfield(slice, symb)
     else
         indices = slice.components[symb]
-        return slice.data[indices]
+        return view(slice.data, indices)
     end
 end
 
@@ -26,6 +26,10 @@ function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     else
         update!(slice, symb, val)
     end
+end
+
+function Base.setindex!(slice::KnotPoint, symb::Symbol, val::Any)
+    setproperty!(slice, symb, val)
 end
 
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -4,6 +4,12 @@ using TestItems
 
 using ..StructKnotPoint
 
+
+"""
+    getproperty(slice::KnotPoint, symb::Symbol)
+
+Returns the component of the knot point with name `symb` (as a view) or the property of the knot point with name `symb`.
+"""
 function Base.getproperty(slice::KnotPoint, symb::Symbol)
     if symb in fieldnames(KnotPoint)
         return getfield(slice, symb)
@@ -22,6 +28,11 @@ function Base.getindex(slice::KnotPoint, symb::Symbol) # is this method redundan
     end
 end
 
+"""
+    setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
+
+Dispatches setting properties of knot points as either setting a component or a property via `update!` or `setfield!`, respectively.
+"""
 function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     if symb in fieldnames(KnotPoint)
         setfield!(slice, symb, val) # will throw error since KnotPoint is an immutable struct
@@ -35,6 +46,11 @@ function Base.setindex!(slice::KnotPoint, symb::Symbol, val::Any)
 end
 
 
+"""
+    update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
+
+Update a component of the knot point.
+"""
 function update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
     @assert symb in slice.names
     @assert size(data, 1) == (slice.components[symb].stop - slice.components[symb].start + 1)

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -7,7 +7,7 @@ function Base.getproperty(slice::KnotPoint, symb::Symbol)
         return getfield(slice, symb)
     else
         indices = slice.components[symb]
-        return slice.data[indices]
+        return view(slice.data, indices)
     end
 end
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -1,5 +1,7 @@
 module MethodsKnotPoint
 
+using TestItems
+
 using ..StructKnotPoint
 
 function Base.getproperty(slice::KnotPoint, symb::Symbol)
@@ -41,5 +43,29 @@ function update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
     return nothing
 end
 
+
+@testitem "Updating trajectory knot points via view" begin
+    traj = rand(NamedTrajectory, 5)
+
+    x_orig = deepcopy(traj.x[:, :])
+    u_orig = deepcopy(traj.u[:, :])
+
+    x_new = rand(size(x_orig)...)
+    u_new = rand(size(u_orig)...)
+
+    idx = rand(1:traj.T)
+
+    traj[idx].x = deepcopy(x_new[:, idx])
+    @test traj.x[:, idx] == traj.data[traj.components.x, idx] == traj[idx].x == x_new[:, idx]
+
+    traj[idx].u = deepcopy(u_new[:, idx])
+    @test traj.u[:, idx] == traj.data[traj.components.u, idx] == traj[idx].u == u_new[:, idx]
+
+    traj.data[traj.components.x, idx] = deepcopy(x_orig[:, idx])
+    @test traj.x[:, idx] == traj.data[traj.components.x, idx] == traj[idx].x == x_orig[:, idx]
+
+    traj.data[traj.components.u, idx] = deepcopy(u_orig[:, idx])
+    @test traj.u[:, idx] == traj.data[traj.components.u, idx] == traj[idx].u == u_orig[:, idx]
+end
 
 end

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -22,14 +22,14 @@ end
 
 function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     if symb in fieldnames(KnotPoint)
-        setfield!(slice, symb, val)
+        setfield!(slice, symb, val) # will throw error since KnotPoint is an immutable struct
     else
         update!(slice, symb, val)
     end
 end
 
 
-function Base.update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
+function update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
     @assert symb in slice.names
     @assert size(data, 1) == (slice.components[symb].stop - slice.components[symb].start + 1)
 

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -386,9 +386,7 @@ function update!(traj::NamedTrajectory, name::Symbol, data::AbstractMatrix{Float
     @assert name ∈ traj.names
     @assert size(data, 1) == traj.dims[name]
     @assert size(data, 2) == traj.T
-    # TODO: test to see if updating both matrix and vec is necessary
     traj.data[traj.components[name], :] = data
-    traj.datavec = vec(view(traj.data, :, :))
     return nothing
 end
 

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -78,7 +78,7 @@ function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
         return getfield(traj, symb)
     else
         indices = traj.components[symb]
-        return traj.data[indices, :]
+        return view(traj.data, indices, :)
     end
 end
 

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -1279,4 +1279,26 @@ end
     @test get_suffix(new_traj, suffix, remove=true) == free_time_traj
 end
 
+@testitem "Updating trajectory components via view" begin
+    traj = rand(NamedTrajectory, 5)
+
+    x_orig = deepcopy(traj.x[:, :])
+    u_orig = deepcopy(traj.u[:, :])
+
+    x_new = rand(size(x_orig)...)
+    u_new = rand(size(u_orig)...)
+
+    traj.x = deepcopy(x_new)
+    @test traj.x == traj.data[traj.components.x, :] == x_new
+
+    traj.u = deepcopy(u_new)
+    @test traj.u == traj.data[traj.components.u, :] == u_new
+
+    traj.data[traj.components.x, :] = deepcopy(x_orig)
+    @test traj.x == traj.data[traj.components.x, :] == x_orig
+
+    traj.data[traj.components.u, :] = deepcopy(u_orig)
+    @test traj.u == traj.data[traj.components.u, :] == u_orig
+end
+
 end

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -29,6 +29,13 @@ using ..StructKnotPoint
 # Base indexing
 # -------------------------------------------------------------- #
 
+"""
+    KnotPoint(Z::NamedTrajectory, t::Int)
+
+    # Arguments
+    - `Z::NamedTrajectory`: The trajectory from which the KnotPoint is taken.
+    - `t::Int`: The timestep of the KnotPoint.
+"""
 function StructKnotPoint.KnotPoint(
     Z::NamedTrajectory,
     t::Int
@@ -71,7 +78,7 @@ Base.getindex(traj::NamedTrajectory, symb::Symbol) = getproperty(traj, symb)
 """
     getproperty(traj, symb::Symbol)
 
-Returns the component of the trajectory with name `symb` or the property of the trajectory with name `symb`.
+Returns the component of the trajectory with name `symb` (as a view) or the property of the trajectory with name `symb`.
 """
 function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
     if symb ∈ fieldnames(NamedTrajectory)
@@ -85,7 +92,7 @@ end
 """
     setproperty!(traj, name::Symbol, val::Any)
 
-Dispatches setting properties of trajectories as either setting a component or a property via `setfield!` or `update!`.
+Dispatches setting properties of trajectories as either setting a component or a property via `update!` or `setfield!`, respectively.
 """
 function Base.setproperty!(traj::NamedTrajectory, symb::Symbol, val::Any)
     if symb ∈ fieldnames(NamedTrajectory)

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -35,7 +35,7 @@ function StructKnotPoint.KnotPoint(
 )
     @assert 1 ≤ t ≤ Z.T
     timestep = get_timesteps(Z)[t]
-    return KnotPoint(t, Z.data[:, t], timestep, Z.components, Z.names, Z.control_names)
+    return KnotPoint(t, view(Z.data, :, t), timestep, Z.components, Z.names, Z.control_names)
 end
 
 """

--- a/src/struct_knot_point.jl
+++ b/src/struct_knot_point.jl
@@ -4,6 +4,9 @@ export KnotPoint
 
 using ..StructNamedTrajectory
 
+"""
+    KnotPoint constructor
+"""
 struct KnotPoint
     t::Int
     data::AbstractVector{Float64}

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -83,7 +83,7 @@ end
     NamedTrajectory(component_data; controls=(), timestep=nothing, bounds, initial, final, goal)
 
     # Arguments
-    - `component_data::NamedTuple{names, <:Tuple{Vararg{vals}}} where {names, vals <: AbstractMatrix{R}}`: Components data.
+    - `component_data::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where {names}`: Components data.
     - `controls`: The control variable in component_data, should be type of `Symbol` among `component_data`.
     - `timestep`: Discretizing time step in `component_data`, should be type of `Symbol` among `component_data`.
     - `bounds`: Bounds of the trajectory.
@@ -92,8 +92,7 @@ end
     - `goal`: Goal for the states.
 """
 function NamedTrajectory(
-    component_data::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where
-        {names};
+    component_data::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where {names};
     controls::Union{Symbol, Tuple{Vararg{Symbol}}}=(),
     timestep::Union{Nothing,Symbol,R}=nothing,
     bounds=(;),
@@ -235,7 +234,7 @@ end
     NamedTrajectory(component_data; kwargs...)
 
     # Arguments
-    - `component_data::NamedTuple{names, <:Tuple{Vararg{vals}}} where {names, vals <: AbstractMatrix{R}}`: Components data.
+    - `component_data::NamedTuple`: Components data. Values should be of type `Union{AbstractVector{<:Real}, AbstractMatrix{<:Real}}`.
     - `kwargs...`: The other key word arguments.
 """
 function NamedTrajectory(

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -92,8 +92,8 @@ end
     - `goal`: Goal for the states.
 """
 function NamedTrajectory(
-    component_data::NamedTuple{names, <:Tuple{Vararg{vals}}} where
-        {names, vals <: AbstractMatrix{R}};
+    component_data::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where
+        {names};
     controls::Union{Symbol, Tuple{Vararg{Symbol}}}=(),
     timestep::Union{Nothing,Symbol,R}=nothing,
     bounds=(;),

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -455,7 +455,7 @@ function NamedTrajectory(
 end
 
 """
-    NamedTrajectory(data, componets; kwargs...)
+    NamedTrajectory(data, components; kwargs...)
 
     # Arguments
     - `data::AbstractMatrix{R}`: Trajectory data.


### PR DESCRIPTION
Generalizes #69. See #69 for discussion of changes pertinent to `KnotPoint`s (relevant commits are included here).

Does not pass tests; namely, `merge()` fails for free-time trajectories. Stack trace includes a StackOverflowError due to repeated calls to `NamedTrajectory(component_data::@NamedTuple{…}; kwargs::@Kwargs{…})`. Root cause is as follows.
- `merge()` creates an intermediate `NamedTuple` of trajectory components, to which it adds the timestep component via a call to `get_timesteps()`, which returns a `Vector{Float64}`.
- Without `free_time == true`, the `NamedTuple` of components satisfies `components <: NamedTuple{names, <:Tuple{Vararg{vals}}} where {R<:Real, names, vals<:AbstractMatrix{R}}`. However, the addition of the timestep component causes this test to fail.
- As a result, the call to `NamedTrajectory()` is dispatched to the method `NamedTrajectory(::NamedTuple; kwargs...)` as opposed to the method `NamedTrajectory(::NamedTuple{names, <:Tuple{Vararg{vals}}} where {names, vals <: AbstractMatrix{R}}; kwargs...) where R <: Real`.
- The former method is meant to convert any vectors among the components to matrices before dispatching to the latter method; however, the resulting conversion fails to satisfy the type constraints of the latter method.

A potential fix could entail changing the type signature of the components argument of the constructor to `NamedTuple{names, vals} where {R <: Real, names, vals <: Tuple{Vararg{AbstractMatrix{R}}}}`; the downstream effects of this are yet to be assessed.