### PR TITLE
Upgrade NT to parametric type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.3.3"
+version = "0.4.0"
 
 [deps]
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -19,6 +20,7 @@ PlottingExt = ["Makie"]
 
 [compat]
 JLD2 = "0.5"
+LazyArrays = "2.6"
 Makie = "0.22"
 OrderedCollections = "1.7"
 Reexport = "1.2"

--- a/docs/literate/man/constructors.jl
+++ b/docs/literate/man/constructors.jl
@@ -18,7 +18,7 @@ components = (
 
 # we must specify a timestep and control variable for the trajectory.
 
-timestep = 0.1
+timestep = :Δt
 control = :u
 
 # we can now create a `NamedTrajectory` object.
@@ -27,4 +27,6 @@ traj = NamedTrajectory(components; timestep=timestep, controls=control)
 
 # Construct `NamedTrajectory` from previous constructed one.
 
-traj = NamedTrajectory(components, traj)
+# `traj = NamedTrajectory(components, traj) # TODO: should this constructor be reimplemented for v0.4.0?`
+
+traj = NamedTrajectory(traj; components=(x=1:3, u=4:5, Δt=6:6))

--- a/docs/literate/man/modifying.jl
+++ b/docs/literate/man/modifying.jl
@@ -20,7 +20,7 @@ traj.names
 
 # Add a new state variable `y` to the trajectory. Notice this is in-place.
 y_data = rand(4, 5)
-add_component!(traj, :y, y_data)
+traj = add_component(traj, :y, y_data)
 traj.names
 
 # Remove the state variable `y` from the trajectory. This is not in place.

--- a/docs/literate/man/modifying.jl
+++ b/docs/literate/man/modifying.jl
@@ -74,8 +74,8 @@ original_traj.names
 conflicting_traj = rand(NamedTrajectory, 5)
 traj.names, conflicting_traj.names
 
-# In this case, keep the `u` data from the first trajectory and the `x` data from the second trajectory
-merged_traj = merge(traj, conflicting_traj; merge_names=(u=1, x=2,))
+# In this case, keep the `u` data from the first trajectory and the `x` data and timestep from the second trajectory
+merged_traj = merge(traj, conflicting_traj; merge_names=(u=1, x=2, Δt=2))
 println(merged_traj.u == traj.u, ", ", merged_traj.u == conflicting_traj.u)
 println(merged_traj.x == traj.x, ", ", merged_traj.x == conflicting_traj.x)
 
@@ -147,12 +147,6 @@ traj = rand(NamedTrajectory, 5)
 println(traj.datavec == traj.data[:])
 traj.datavec = rand(length(traj.datavec))
 println(traj.datavec == traj.data[:]) # the `data` field now points to a "backing store" that is no longer accessible via `traj.datavec`; this will lead to undefined behavior:
-
-# The following is likewise an "unsafe" operation (non-in-place modification of `data`, replacing a "view" of `datavec` with a "raw" matrix):
-traj = rand(NamedTrajectory, 5)
-println(traj.datavec == traj.data[:])
-traj.data = rand(size(traj.data)...)
-println(traj.datavec == traj.data[:]) # the `data` field no longer points to any "backing store", i.e. is independent of `traj.datavec`; this will lead to undefined behavior:
 
 # In general, reassigning the values of any of the fields of a trajectory may lead to undefined behavior:
 fieldnames(NamedTrajectory)

--- a/docs/literate/man/params_in_struct.jl
+++ b/docs/literate/man/params_in_struct.jl
@@ -16,7 +16,7 @@ components = (
 
 # we must specify a timestep and control variable for the trajectory.
 
-timestep = 0.1
+timestep = :Δt
 control = :u
 
 # some global params as a NamedTuple
@@ -26,4 +26,4 @@ params = (
 )
 
 # we can now create a `NamedTrajectory` object with parameters specification.
-traj = NamedTrajectory(components; timestep=timestep, controls=control, global_data=params)
+traj = NamedTrajectory(components, params; timestep=timestep, controls=control)

--- a/docs/literate/plotting.jl
+++ b/docs/literate/plotting.jl
@@ -61,9 +61,10 @@ traj = NamedTrajectory(
     (
         x=X,
         u=U,
-        v=V
+        v=V,
+        Δt=fill(Δt, T),
     );
-    timestep=Δt,
+    timestep=:Δt,
     controls=(:u, :v)
 )
 

--- a/docs/literate/quickstart.jl
+++ b/docs/literate/quickstart.jl
@@ -19,56 +19,26 @@ using NamedTrajectories
 ```math
 \qty{z_t = \mqty(x_t \\ u_t)}_{t=1:T}
 ```
+
+where $x_t$ is the state and $u_t$ is the control at a time indexed by $t$. Together $z_t$ is referred to as a *knot point* and a `NamedTrajectory` essentially just stores a collection of knot points and makes it easy to access the state and control variables.
+
+## Creating a variable-timestep `NamedTrajectory`
+
+Here we will create a `NamedTrajectory` with a variable timestep.
 =#
 
-# where $x_t$ is the state and $u_t$ is the control at a time indexed by $t$. Together $z_t$ is referred to as a *knot point* and a `NamedTrajectory` essentially just stores a collection of knot points and makes it easy to access the state and control variables.
-
-
-# ## Creating a fixed-timestep `NamedTrajectory`
-
-# Here we will createa a `NamedTrajectory` with a fixed timestep. This is done by passing a scalar as the `timestep` kwarg.
-
 ## define the number of timesteps
 T = 10
+Δt = 0.1
 
 ## define the knot point data as a NamedTuple of matrices
 data = (
     x = rand(3, T),
     u = rand(2, T),
+    Δt = fill(Δt, T),
 )
 
-## we must specify a timestep and control variable for the trajectory
-timestep = 0.1
-control = :u
-
-## we can now create a `NamedTrajectory` object
-traj = NamedTrajectory(data; timestep=timestep, controls=control)
-
-## we can return the names of the stored variables
-traj.names
-
-# Let's plot this trajectory
-# Use a Makie backend to automatically load the NamedTrajectories plotting extension
-using CairoMakie
-
-plot(traj)
-
-
-# ## Creating a variable-timestep `NamedTrajectory`
-
-# Here we will create a `NamedTrajectory` with a variable timestep. This is done by passing a `Symbol`, corresponding to component of the data, as the `timestep` kwarg.
-
-## define the number of timesteps
-T = 10
-
-## define the knot point data as a NamedTuple of matrices
-data = (
-    x = rand(3, T),
-    u = rand(2, T),
-    Δt = rand(T),
-)
-
-## we must specify a timestep and control variable for the NamedTrajectory
+## we must specify a timestep and control variable for the NamedTrajectory.
 timestep = :Δt
 control = :u
 
@@ -79,9 +49,11 @@ traj = NamedTrajectory(data; timestep=timestep, controls=control)
 traj.names
 
 
-# ## Adding more problem data
+#=
+## Adding more problem data
 
-# In many settings we will want to add problem data to our `NamedTrajectory` -- e.g. bounds, initial values, final values, and goal values. This is realized by passing NamedTuples containing this data.
+In many settings we will want to specify the problem data of our `NamedTrajectory` -- e.g. bounds, initial values, final values, and goal values. 
+=#
 
 ## define the number of timesteps
 T = 10
@@ -131,7 +103,7 @@ traj = NamedTrajectory(
 )
 
 ## we can then show the bounds
-traj.goal
+traj.bounds
 
 
 # ## Retrieving data
@@ -186,3 +158,17 @@ traj.T
 traj.components
 
 # returns the components of the trajectory.
+
+#=
+## Updating problem data
+
+The `NamedTrajectory` can be updated by accessing fields and replacing the data.
+
+
+We also have `update!` to update trajectory components, and  `update_bound!`, which allows you to pass in the same kinds of bounds available at construction (e.g., an `Int` or `Tuple`). The bound will get shaped to match the trajectory component dimensions just like at construction.These methods cannot be used to update non-existent bounds or components.
+
+For efficiency, a trajectory cannot add new data after it is constructed. However, we have convenience methods like `add_component` that build a new trajectory with added data.
+
+=#
+
+update_bound!(traj, :x, )

--- a/docs/literate/quickstart.jl
+++ b/docs/literate/quickstart.jl
@@ -165,10 +165,10 @@ traj.components
 The `NamedTrajectory` can be updated by accessing fields and replacing the data.
 
 
-We also have `update!` to update trajectory components, and  `update_bound!`, which allows you to pass in the same kinds of bounds available at construction (e.g., an `Int` or `Tuple`). The bound will get shaped to match the trajectory component dimensions just like at construction.These methods cannot be used to update non-existent bounds or components.
+We also have `update!` to update trajectory components, and  `update_bound!`, which allows you to pass in the same kinds of bounds available at construction (e.g., an `Int` or `Tuple`). The bound will get shaped to match the trajectory component dimensions just like at construction. These methods cannot be used to update non-existent bounds or components.
 
 For efficiency, a trajectory cannot add new data after it is constructed. However, we have convenience methods like `add_component` that build a new trajectory with added data.
 
 =#
 
-update_bound!(traj, :x, )
+update_bound!(traj, :x, 2.) # TODO: consider fleshing out this section with more examples of updating trajectory components, knot points, globals, bounds, etc.

--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -3,9 +3,7 @@ module PlottingExt
 using NamedTrajectories
 import NamedTrajectories: namedplot, namedplot!
 
-# Ideally, we'd only need MakieCore for recipes
-# But, we need Series, Axis, Figure etc. 
-# And it's recommended to use Makie for ext
+# recommended to use Makie for ext
 using Makie
 
 using TestItems
@@ -49,6 +47,11 @@ function Makie.convert_arguments(
         end
     else
         transform_data = traj[name]
+    end
+
+    # If 1D, convert to 2D
+    if transform_data isa AbstractVector
+        transform_data = reshape(transform_data, 1, :)
     end
 
     return Makie.convert_arguments(P, get_times(traj), transform_data)

--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -217,7 +217,7 @@ function Makie.plot(
     # transformation keyword arguments
     # ---------------------------------------------------------------------------
 
-    # transformations, e.g. [(:x => x -> [x[1]; x[2]]), ...]
+    # transformations, e.g., [(:x => x -> [x[1]; abs(x[2])]), ...]
     transformations::AbstractVector{<:Pair{Symbol, <:AbstractTransform}} = Pair{Symbol, Function}[],
 
     # labels for transformed components

--- a/src/NamedTrajectories.jl
+++ b/src/NamedTrajectories.jl
@@ -10,6 +10,9 @@ include("struct_named_trajectory.jl")
 include("struct_knot_point.jl")
 @reexport using .StructKnotPoint
 
+include("base_named_trajectory.jl")
+@reexport using .BaseNamedTrajectory
+
 include("methods_named_trajectory.jl")
 @reexport using .MethodsNamedTrajectory
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -7,10 +7,17 @@ using ..StructKnotPoint
 
 
 function Base.show(io::IO, Z::NamedTrajectory)
+    @inline function format(name, inds)
+        str = name == Z.timestep ? "→ " * String(name) : String(name)
+        return "$(str) = $(inds)"
+    end
+
+    comp_str = join([format(n, Z.components[n]) for n in keys(Z.components)], ", ")
     if isempty(Z.global_data)
-        print(io, Z.components, ", T = ", Z.T)
+        print(io, "T = ", Z.T, ", (", comp_str, ")")
     else
-        print(io, Z.components, ", T = ", Z.T, ", ", Z.global_components)
+        global_comp_str = join([format(n, Z.global_components[n]) for n in keys(Z.global_components)], ", ")
+        print(io, "T = ", Z.T, ", (", comp_str, "), (", global_comp_str, ")")
     end
 end
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -7,10 +7,10 @@ using ..StructKnotPoint
 
 
 function Base.show(io::IO, Z::NamedTrajectory)
-    if isempty(Z.gdata)
+    if isempty(Z.global_data)
         print(io, Z.components, ", T = ", Z.T)
     else
-        print(io, Z.components, ", T = ", Z.T, ", ", Z.gcomponents)
+        print(io, Z.components, ", T = ", Z.T, ", ", Z.global_components)
     end
 end
 
@@ -22,9 +22,9 @@ function Base.length(Z::NamedTrajectory)
 end
 
 """
-    size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
+    size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, global_dim = Z.global_dim)
 """
-Base.size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
+Base.size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, global_dim = Z.global_dim)
 
 """
     copy(::NamedTrajectory)
@@ -32,7 +32,7 @@ Base.size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
 Returns a copy of the trajectory data and global data.
 """
 function Base.copy(traj::NamedTrajectory)
-    return NamedTrajectory(deepcopy(traj.datavec), traj, gdata=deepcopy(traj.gdata))
+    return NamedTrajectory(deepcopy(traj.datavec), traj, global_data=deepcopy(traj.global_data))
 end
 
 # -------------------------------------------------------------- #
@@ -98,9 +98,9 @@ function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
     elseif symb in traj.names
         indices = traj.components[symb]
         return view(traj.data, indices, :)
-    elseif symb in traj.gnames
-        indices = traj.gcomponents[symb]
-        return view(traj.gdata, indices)
+    elseif symb in traj.global_names
+        indices = traj.global_components[symb]
+        return view(traj.global_data, indices)
     end
 end
 
@@ -139,11 +139,11 @@ function Base.isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
     end
 
     # check global components
-    if !issetequal(traj1.gnames, traj2.gnames)
+    if !issetequal(traj1.global_names, traj2.global_names)
         return false
     end
 
-    for gname in traj1.gnames
+    for gname in traj1.global_names
         if !isequal(traj1[gname], traj2[gname])
             return false
         end
@@ -198,11 +198,11 @@ end
 
    traj1 = NamedTrajectory(
         data, (x = 1:3, y=4:4, z=5:5), timestep=:z,
-        gdata=[1.0, 2.0, 3.0], gcomponents=(a=1:2, b=3:3)
+        global_data=[1.0, 2.0, 3.0], global_components=(a=1:2, b=3:3)
     )
     traj2 = NamedTrajectory(
         data, (x = 1:3, y=4:4, z=5:5), timestep=:z,
-        gdata=[3.0, 1.0, 2.0], gcomponents=(a=2:3, b=1:1)
+        global_data=[3.0, 1.0, 2.0], global_components=(a=2:3, b=1:1)
     )
     @test traj1 == traj2
 end
@@ -211,20 +211,20 @@ end
     using Random
     data1 = randn(5, 10)
     data2 = copy(data1)
-    gdata1 = [1.0, 2.0, 3.0]
-    gdata2 = copy(gdata1)
+    global_data1 = [1.0, 2.0, 3.0]
+    global_data2 = copy(global_data1)
     traj1 = NamedTrajectory(
         data1, (x = 1:3, y=4:4, z=5:5), timestep=:z,
-        gdata=gdata1, gcomponents=(a=1:2, b=3:3)
+        global_data=global_data1, global_components=(a=1:2, b=3:3)
     )
     traj2 = copy(traj1)
     traj1.data .= 0
     @test traj1.data == zeros(size(data1))
     @test traj2.data == data2
     
-    traj1.gdata .= 0
-    @test traj1.gdata == zeros(size(gdata1))
-    @test traj2.gdata == gdata2
+    traj1.global_data .= 0
+    @test traj1.global_data == zeros(size(global_data1))
+    @test traj2.global_data == global_data2
 
 end
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -6,7 +6,13 @@ using ..StructNamedTrajectory
 using ..StructKnotPoint
 
 
-Base.show(io::IO, Z::NamedTrajectory) = print(io, Z.components, ", T = ", Z.T)
+function Base.show(io::IO, Z::NamedTrajectory)
+    if isempty(Z.gdata)
+        print(io, Z.components, ", T = ", Z.T)
+    else
+        print(io, Z.components, ", T = ", Z.T, ", ", Z.gcomponents)
+    end
+end
 
 """
     length(Z::NamedTrajectory) = Z.dim * Z.T + Z.global_dim

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -51,7 +51,7 @@ function StructKnotPoint.KnotPoint(
     t::Int
 )
     @assert 1 ≤ t ≤ Z.T
-    timestep = get_timesteps(Z)[t]
+    timestep = Z[Z.timestep][t]
     return KnotPoint(t, view(Z.data, :, t), timestep, Z.components, Z.names, Z.control_names)
 end
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -113,7 +113,7 @@ function Base.setproperty!(traj::NamedTrajectory, symb::Symbol, val::Any)
     if symb ∈ fieldnames(NamedTrajectory)
         setfield!(traj, symb, val)
     else
-        update!(traj, symb, val)
+        traj.data[traj.components[symb], :] = val
     end
 end
 
@@ -230,7 +230,6 @@ end
 
 @testitem "knot point methods" begin
     include("../test/test_utils.jl")
-    fixed_time_traj = get_fixed_time_traj()
     free_time_traj = get_free_time_traj()
 
     # freetime
@@ -240,43 +239,24 @@ end
     @test free_time_traj[end].x == free_time_traj.x[:, end]
     @test free_time_traj[:x] == free_time_traj.x
     @test free_time_traj.timestep isa Symbol
-
-    # fixed time
-    @test fixed_time_traj[1] isa KnotPoint
-    @test fixed_time_traj[1].x == fixed_time_traj.x[:, 1]
-    @test fixed_time_traj[end] isa KnotPoint
-    @test fixed_time_traj[end].x == fixed_time_traj.x[:, end]
-    @test fixed_time_traj[:x] == fixed_time_traj.x
-    @test fixed_time_traj.timestep isa Float64
 end
 
 @testitem "algebraic methods" begin
     include("../test/test_utils.jl")
-    fixed_time_traj = get_fixed_time_traj()
     free_time_traj = get_free_time_traj()
     free_time_traj2 = copy(free_time_traj)
-    fixed_time_traj2 = copy(fixed_time_traj)
 
     @test (free_time_traj + free_time_traj2).x == free_time_traj.x + free_time_traj2.x
-    @test (fixed_time_traj + fixed_time_traj2).x == fixed_time_traj.x + fixed_time_traj2.x
-
     @test (free_time_traj - free_time_traj2).x == free_time_traj.x - free_time_traj2.x
-    @test (fixed_time_traj - fixed_time_traj2).x == fixed_time_traj.x - fixed_time_traj2.x
-
     @test (2.0 * free_time_traj).x == (free_time_traj * 2.0).x == free_time_traj.x * 2.0
-    @test (2.0 * fixed_time_traj).x == (fixed_time_traj * 2.0).x == fixed_time_traj.x * 2.0
 end
 
 @testitem "copying and equality checks" begin
     include("../test/test_utils.jl")
-    fixed_time_traj = get_fixed_time_traj()
     free_time_traj = get_free_time_traj()
 
-    fixed_time_traj_copy = copy(fixed_time_traj)
     free_time_traj_copy = copy(free_time_traj)
-
-    @test isequal(fixed_time_traj, fixed_time_traj_copy)
-    @test fixed_time_traj == fixed_time_traj_copy
+    @test free_time_traj == free_time_traj_copy
 end
 
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -1,0 +1,197 @@
+module BasedNamedTrajectory
+
+using ..StructNamedTrajectory
+using ..StructKnotPoint
+
+
+Base.show(io::IO, Z::NamedTrajectory) = print(io, Z.components, ", T = ", Z.T)
+
+"""
+    length(Z::NamedTrajectory) = Z.dim * Z.T + Z.global_dim
+"""
+function Base.length(Z::NamedTrajectory)
+    return Z.dim * Z.T + Z.global_dim
+end
+
+"""
+    size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
+"""
+Base.size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
+
+# -------------------------------------------------------------- #
+# Base indexing
+# -------------------------------------------------------------- #
+
+"""
+    KnotPoint(Z::NamedTrajectory, t::Int)
+
+    # Arguments
+    - `Z::NamedTrajectory`: The trajectory from which the KnotPoint is taken.
+    - `t::Int`: The timestep of the KnotPoint.
+"""
+function StructKnotPoint.KnotPoint(
+    Z::NamedTrajectory,
+    t::Int
+)
+    @assert 1 ≤ t ≤ Z.T
+    timestep = get_timesteps(Z)[t]
+    return KnotPoint(t, view(Z.data, :, t), timestep, Z.components, Z.names, Z.control_names)
+end
+
+"""
+    getindex(traj, t::Int)::KnotPoint
+
+Returns the knot point at time `t`.
+"""
+Base.getindex(traj::NamedTrajectory, t::Int) = KnotPoint(traj, t)
+
+"""
+    getindex(traj, ts::AbstractVector{Int})::Vector{KnotPoint}
+
+Returns the knot points at times `ts`.
+"""
+function Base.getindex(traj::NamedTrajectory, ts::AbstractVector{Int})::Vector{KnotPoint}
+    return [traj[t] for t ∈ ts]
+end
+
+"""
+    lastindex(traj::NamedTrajectory)
+
+Returns the final time index of the trajectory.
+"""
+Base.lastindex(traj::NamedTrajectory) = traj.T
+
+"""
+    getindex(traj, symb::Symbol)
+
+Dispatches indexing of trajectories as either accessing a component or a property via `getproperty`.
+"""
+Base.getindex(traj::NamedTrajectory, symb::Symbol) = getproperty(traj, symb)
+
+"""
+    getproperty(traj, symb::Symbol)
+
+Returns the component of the trajectory with name `symb` (as a view) or the property of the trajectory with name `symb`.
+"""
+function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
+    if symb == :data
+        return reshape(view(traj.datavec, :), :, traj.T)
+    elseif symb ∈ fieldnames(NamedTrajectory)
+        return getfield(traj, symb)
+    elseif symb in traj.names
+        indices = traj.components[symb]
+        return view(traj.data, indices, :)
+    elseif symb in traj.gnames
+        indices = traj.gcomps[symb]
+        return view(traj.gdata, indices, :)
+    end
+end
+
+"""
+    setproperty!(traj, name::Symbol, val::Any)
+
+Dispatches setting properties of trajectories as either setting a component or a property via `update!` or `setfield!`, respectively.
+"""
+function Base.setproperty!(traj::NamedTrajectory, symb::Symbol, val::Any)
+    if symb ∈ fieldnames(NamedTrajectory)
+        setfield!(traj, symb, val)
+    else
+        update!(traj, symb, val)
+    end
+end
+
+# -------------------------------------------------------------- #
+# Get components, Equality
+# -------------------------------------------------------------- #
+
+"""
+    get_components(names, ::NamedTrajectory)
+
+Returns a NamedTuple containing the names and corresponding data matrices of the trajectory.
+"""
+function get_components(cnames::Union{Tuple, AbstractVector}, traj::NamedTrajectory)
+    symbs = Tuple(c for c in cnames)
+    vals = [traj[c] for c ∈ cnames]
+    return NamedTuple{symbs}(vals)
+end
+
+get_components(traj::NamedTrajectory) = get_components(traj.names, traj)
+
+"""
+    get_global_components(names, ::NamedTrajectory)
+
+Returns a NamedTuple containing the names and corresponding data vector of the globals.
+"""
+function get_global_components(cnames::Union{Tuple, AbstractVector}, traj::NamedTrajectory)
+    symbs = Tuple(c for c in cnames)
+    vals = [traj.gdata[traj.gcomps[c]] for c ∈ cnames]
+    return NamedTuple{symbs}(vals)
+end
+
+get_components(traj::NamedTrajectory) = get_components(traj.names, traj)
+
+"""
+    isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
+
+Check if trajectories are equal w.r.t. data using `Base.isequal`
+"""
+function Base.isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
+    # check components
+    if !issetequal(traj1.names, traj2.names)
+        return false
+    end
+
+    comps1 = get_components(traj1)
+    comps2 = get_components(traj2)
+    for (name, data1) in pairs(comps1)
+        if !isequal(data1, comps2[name])
+            return false
+        end
+    end
+
+    # check global components
+    if !issetequal(traj1.gnames, traj2.gnames)
+        return false
+    end
+
+       
+    return true
+end
+
+"""
+    :(==)(traj1::NamedTrajectory, traj2::NamedTrajectory)
+
+Check if trajectories are equal w.r.t. using `Base.:(==)`
+"""
+function Base.:(==)(traj1::NamedTrajectory, traj2::NamedTrajectory)
+    return isequal(traj1, traj2)
+end
+
+# -------------------------------------------------------------- #
+# Base math
+# -------------------------------------------------------------- #
+
+function Base.:*(α::Float64, traj::NamedTrajectory)
+    return NamedTrajectory(α * traj.datavec, traj)
+end
+
+function Base.:*(traj::NamedTrajectory, α::Float64)
+    return NamedTrajectory(α * traj.datavec, traj)
+end
+
+function Base.:+(traj1::NamedTrajectory, traj2::NamedTrajectory)
+    @assert traj1.names == traj2.names
+    @assert traj1.dim == traj2.dim
+    @assert traj1.T == traj2.T
+    return NamedTrajectory(traj1.datavec + traj2.datavec, traj1)
+end
+
+function Base.:-(traj1::NamedTrajectory, traj2::NamedTrajectory)
+    @assert traj1.names == traj2.names
+    @assert traj1.dim == traj2.dim
+    @assert traj1.T == traj2.T
+    return NamedTrajectory(traj1.datavec - traj2.datavec, traj1)
+end
+
+
+end

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -94,7 +94,7 @@ function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
         return view(traj.data, indices, :)
     elseif symb in traj.gnames
         indices = traj.gcomponents[symb]
-        return view(traj.gdata, indices, :)
+        return view(traj.gdata, indices)
     end
 end
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -1,4 +1,6 @@
-module BasedNamedTrajectory
+module BaseNamedTrajectory
+
+using TestItems
 
 using ..StructNamedTrajectory
 using ..StructKnotPoint
@@ -17,6 +19,15 @@ end
     size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
 """
 Base.size(Z::NamedTrajectory) = (dim = Z.dim, T = Z.T, gdim = Z.gdim)
+
+"""
+    copy(::NamedTrajectory)
+
+Returns a copy of the trajectory data and global data.
+"""
+function Base.copy(traj::NamedTrajectory)
+    return NamedTrajectory(deepcopy(traj.datavec), traj, gdata=deepcopy(traj.gdata))
+end
 
 # -------------------------------------------------------------- #
 # Base indexing
@@ -82,7 +93,7 @@ function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
         indices = traj.components[symb]
         return view(traj.data, indices, :)
     elseif symb in traj.gnames
-        indices = traj.gcomps[symb]
+        indices = traj.gcomponents[symb]
         return view(traj.gdata, indices, :)
     end
 end
@@ -101,34 +112,8 @@ function Base.setproperty!(traj::NamedTrajectory, symb::Symbol, val::Any)
 end
 
 # -------------------------------------------------------------- #
-# Get components, Equality
+# Equality
 # -------------------------------------------------------------- #
-
-"""
-    get_components(names, ::NamedTrajectory)
-
-Returns a NamedTuple containing the names and corresponding data matrices of the trajectory.
-"""
-function get_components(cnames::Union{Tuple, AbstractVector}, traj::NamedTrajectory)
-    symbs = Tuple(c for c in cnames)
-    vals = [traj[c] for c ∈ cnames]
-    return NamedTuple{symbs}(vals)
-end
-
-get_components(traj::NamedTrajectory) = get_components(traj.names, traj)
-
-"""
-    get_global_components(names, ::NamedTrajectory)
-
-Returns a NamedTuple containing the names and corresponding data vector of the globals.
-"""
-function get_global_components(cnames::Union{Tuple, AbstractVector}, traj::NamedTrajectory)
-    symbs = Tuple(c for c in cnames)
-    vals = [traj.gdata[traj.gcomps[c]] for c ∈ cnames]
-    return NamedTuple{symbs}(vals)
-end
-
-get_components(traj::NamedTrajectory) = get_components(traj.names, traj)
 
 """
     isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
@@ -141,10 +126,8 @@ function Base.isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
         return false
     end
 
-    comps1 = get_components(traj1)
-    comps2 = get_components(traj2)
-    for (name, data1) in pairs(comps1)
-        if !isequal(data1, comps2[name])
+    for name in traj1.names
+        if !isequal(traj1[name], traj2[name])
             return false
         end
     end
@@ -154,6 +137,11 @@ function Base.isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
         return false
     end
 
+    for gname in traj1.gnames
+        if !isequal(traj1[gname], traj2[gname])
+            return false
+        end
+    end
        
     return true
 end
@@ -191,6 +179,98 @@ function Base.:-(traj1::NamedTrajectory, traj2::NamedTrajectory)
     @assert traj1.dim == traj2.dim
     @assert traj1.T == traj2.T
     return NamedTrajectory(traj1.datavec - traj2.datavec, traj1)
+end
+
+# =========================================================================== #
+
+@testitem "equality" begin
+    using Random
+    data = randn(5, 10)
+    traj1 = NamedTrajectory(data, (x = 1:3, y=4:4, z=5:5), timestep=:z)
+    traj2 = NamedTrajectory(data[[5,4,1,2,3], :], (z=1:1, y=2:2, x=3:5), timestep=:z)
+    @test traj1 == traj2
+
+   traj1 = NamedTrajectory(
+        data, (x = 1:3, y=4:4, z=5:5), timestep=:z,
+        gdata=[1.0, 2.0, 3.0], gcomponents=(a=1:2, b=3:3)
+    )
+    traj2 = NamedTrajectory(
+        data, (x = 1:3, y=4:4, z=5:5), timestep=:z,
+        gdata=[3.0, 1.0, 2.0], gcomponents=(a=2:3, b=1:1)
+    )
+    @test traj1 == traj2
+end
+
+@testitem "copy" begin
+    using Random
+    data1 = randn(5, 10)
+    data2 = copy(data1)
+    gdata1 = [1.0, 2.0, 3.0]
+    gdata2 = copy(gdata1)
+    traj1 = NamedTrajectory(
+        data1, (x = 1:3, y=4:4, z=5:5), timestep=:z,
+        gdata=gdata1, gcomponents=(a=1:2, b=3:3)
+    )
+    traj2 = copy(traj1)
+    traj1.data .= 0
+    @test traj1.data == zeros(size(data1))
+    @test traj2.data == data2
+    
+    traj1.gdata .= 0
+    @test traj1.gdata == zeros(size(gdata1))
+    @test traj2.gdata == gdata2
+
+end
+
+@testitem "knot point methods" begin
+    include("../test/test_utils.jl")
+    fixed_time_traj = get_fixed_time_traj()
+    free_time_traj = get_free_time_traj()
+
+    # freetime
+    @test free_time_traj[1] isa KnotPoint
+    @test free_time_traj[1].x == free_time_traj.x[:, 1]
+    @test free_time_traj[end] isa KnotPoint
+    @test free_time_traj[end].x == free_time_traj.x[:, end]
+    @test free_time_traj[:x] == free_time_traj.x
+    @test free_time_traj.timestep isa Symbol
+
+    # fixed time
+    @test fixed_time_traj[1] isa KnotPoint
+    @test fixed_time_traj[1].x == fixed_time_traj.x[:, 1]
+    @test fixed_time_traj[end] isa KnotPoint
+    @test fixed_time_traj[end].x == fixed_time_traj.x[:, end]
+    @test fixed_time_traj[:x] == fixed_time_traj.x
+    @test fixed_time_traj.timestep isa Float64
+end
+
+@testitem "algebraic methods" begin
+    include("../test/test_utils.jl")
+    fixed_time_traj = get_fixed_time_traj()
+    free_time_traj = get_free_time_traj()
+    free_time_traj2 = copy(free_time_traj)
+    fixed_time_traj2 = copy(fixed_time_traj)
+
+    @test (free_time_traj + free_time_traj2).x == free_time_traj.x + free_time_traj2.x
+    @test (fixed_time_traj + fixed_time_traj2).x == fixed_time_traj.x + fixed_time_traj2.x
+
+    @test (free_time_traj - free_time_traj2).x == free_time_traj.x - free_time_traj2.x
+    @test (fixed_time_traj - fixed_time_traj2).x == fixed_time_traj.x - fixed_time_traj2.x
+
+    @test (2.0 * free_time_traj).x == (free_time_traj * 2.0).x == free_time_traj.x * 2.0
+    @test (2.0 * fixed_time_traj).x == (fixed_time_traj * 2.0).x == fixed_time_traj.x * 2.0
+end
+
+@testitem "copying and equality checks" begin
+    include("../test/test_utils.jl")
+    fixed_time_traj = get_fixed_time_traj()
+    free_time_traj = get_free_time_traj()
+
+    fixed_time_traj_copy = copy(fixed_time_traj)
+    free_time_traj_copy = copy(free_time_traj)
+
+    @test isequal(fixed_time_traj, fixed_time_traj_copy)
+    @test fixed_time_traj == fixed_time_traj_copy
 end
 
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -19,12 +19,11 @@ function Base.getproperty(slice::KnotPoint, symb::Symbol)
     end
 end
 
-function Base.getindex(slice::KnotPoint, symb::Symbol) # is this method redundant? i.e. should we just dispatch to getproperty?
+function Base.getindex(slice::KnotPoint, symb::Symbol)
     if symb in fieldnames(KnotPoint)
         return getfield(slice, symb)
     else
-        indices = slice.components[symb]
-        return view(slice.data, indices)
+        return view(slice.data, slice.components[symb])
     end
 end
 
@@ -35,7 +34,7 @@ Dispatches setting properties of knot points as either setting a component or a 
 """
 function Base.setproperty!(slice::KnotPoint, symb::Symbol, val::Any)
     if symb in fieldnames(KnotPoint)
-        setfield!(slice, symb, val) # will throw error since KnotPoint is an immutable struct
+        setfield!(slice, symb, val) # will error (KnotPoint is an immutable struct)
     else
         update!(slice, symb, val)
     end
@@ -59,6 +58,7 @@ function update!(slice::KnotPoint, symb::Symbol, data::AbstractVector{Float64})
     return nothing
 end
 
+# =========================================================================== #
 
 @testitem "Updating trajectory knot points via view" begin
     traj = rand(NamedTrajectory, 5)

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -15,13 +15,12 @@ export remove_component
 export remove_components
 
 export update!
-
+export update_bound!
 
 # ---
 
 # TODO: Refactor 
 
-export update_bound!
 
 export merge
 export add_suffix
@@ -343,56 +342,20 @@ function update!(traj::NamedTrajectory, datavec::AbstractVector{Float64}; type=:
     return nothing
 end
 
-"""
-    update_bound!(traj, name::Symbol, data::Real)
-    update_bound!(traj, name::Symbol, data::AbstractVector{<:Real})
-    update_bound!(traj, name::Symbol, data::Tuple{R, R} where R <: Real)
+""" 
+    update_bound!(traj, name, new_bound)
 
 Update the bound of a component of the trajectory.
 """
-function update_bound! end
-
 function update_bound!(
     traj::NamedTrajectory,
     name::Symbol,
-    new_bound::Real
+    new_bound
 )
-    @assert new_bound > 0 "bound must be positive"
-    new_bound = (-fill(new_bound, traj.dims[name]), fill(new_bound, traj.dims[name]))
-    update_bound!(traj, name, new_bound)
-end
-
-function update_bound!(
-    traj::NamedTrajectory,
-    name::Symbol,
-    new_bound::AbstractVector{<:Real}
-)
-    @assert all(new_bound .> 0) "bound must be positive"
-    new_bound = (-new_bound, new_bound)
-    update_bound!(traj, name, new_bound)
-end
-
-function update_bound!(
-    traj::NamedTrajectory,
-    name::Symbol,
-    new_bound::Tuple{R, R} where R <: Real
-)
-    @assert new_bound[1] < new_bound[2] "lower bound must be less than upper bound"
-    new_bound = (-fill(new_bound[1], traj.dims[name]), fill(new_bound[2], traj.dims[name]))
-    update_bound!(traj, name, new_bound)
-end
-
-function update_bound!(traj::NamedTrajectory, name::Symbol, new_bound::BoundType)
-    @assert name ∈ keys(traj.components)
-    @assert length(new_bound[1]) == length(new_bound[2]) == traj.dims[name]
-    if isempty(traj.bounds)
-        new_bounds = OrderedDict{Symbol, BoundType}()
-    else
-        new_bounds = OrderedDict(pairs(traj.bounds))
-    end
-    new_bounds[name] = new_bound
-    new_bounds = NamedTuple(new_bounds)
-    traj.bounds = new_bounds
+    @assert name in keys(traj.bounds) "update_bound! requires existing bound"
+    # reuse processing
+    new_bounds = StructNamedTrajectory.get_bounds_from_dims((; name => new_bound,), traj.dims)
+    traj.bounds = merge(traj.bounds, new_bounds)
     return nothing
 end
 
@@ -855,6 +818,22 @@ end
     update!(traj, new_data, type=:both)
     @test traj.data == orig_data
     @test traj.gdata = orig_gdata
+end
+
+@testitem "update bound" begin
+    data = randn(5, 10)
+    traj = NamedTrajectory(
+        data, (x = 1:3, y=4:4, z=5:5), timestep=:z, 
+        bounds=(x = 1,)
+    )
+    update_bound!(traj, :x, 2)
+    @test traj.bounds[:x] == ([-2.0, -2.0, -2.0], [2.0, 2.0, 2.0])
+
+    update_bound!(traj, :x, (0, 3))
+    @test traj.bounds[:x] == ([0.0, 0.0, 0.0], [3.0, 3.0, 3.0])
+
+    update_bound!(traj, :x, [1.0, 1.0, 1.0])
+    @test traj.bounds[:x] == ([-1.0, -1.0, -1.0], [1.0, 1.0, 1.0])
 end
 
 # *** old ***

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -396,9 +396,21 @@ end
 Update the trajectory with a new datavec.
 """
 function update!(traj::NamedTrajectory, datavec::AbstractVector{Float64})
-    @assert length(datavec) == traj.dim * traj.T + traj.global_dim
+    @assert length(datavec) == traj.dim * traj.T
     traj.datavec = datavec
     traj.data = reshape(view(datavec, :), traj.dim, traj.T)
+    return nothing
+end
+
+"""
+    update!(traj::NamedTrajectory, data::NamedTuple)
+
+Update the global data of the trajectory with a NamedTuple.
+"""
+function update!(traj::NamedTrajectory, data::NamedTuple)
+    @assert all([k ∈ keys(traj.global_data) for k in keys(data)])
+    @assert all([length(v) == traj.global_dims[k] for (k, v) in pairs(data)])
+    traj.global_data = merge(traj.global_data, data)
     return nothing
 end
 

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -3,18 +3,19 @@ module MethodsNamedTrajectory
 # Does it make sense to have a mutation?
 # - Yes for data, No for shapes.
 
-export vec
-export get_components
-export get_component_names
+# export vec
 export add_component!
 export remove_component
 export remove_components
 export update!
 export update_bound!
-export merge
+export get_components
+export get_component_names
 export get_times
 export get_timesteps
 export get_duration
+export merge
+
 export convert_fixed_time
 export convert_free_time
 
@@ -27,72 +28,15 @@ using TestItems
 
 using ..StructNamedTrajectory
 using ..StructKnotPoint
+using ..BaseNamedTrajectory
 
-"""
-    copy(::NamedTrajectory)
-
-Returns a copy of the trajectory.
-"""
-function Base.copy(traj::NamedTrajectory)
-    return NamedTrajectory(deepcopy(traj.data), traj)
-end
-
-"""
-    isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
-
-Check if trajectories are equal w.r.t. data using `Base.isequal`
-"""
-function Base.isequal(traj1::NamedTrajectory, traj2::NamedTrajectory)
-    if isequal(traj1.data, traj2.data) &&
-        isequal(traj1.names, traj2.names)
-        return true
-    else
-        return false
-    end
-end
-
-"""
-    :(==)(traj1::NamedTrajectory, traj2::NamedTrajectory)
-
-Check if trajectories are equal w.r.t. using `Base.:(==)`
-"""
-function Base.:(==)(traj1::NamedTrajectory, traj2::NamedTrajectory)
-    if traj1.data == traj2.data &&
-        traj1.names == traj2.names
-        return true
-    else
-        return false
-    end
-end
-
-function Base.:*(α::Float64, traj::NamedTrajectory)
-    return NamedTrajectory(α * traj.datavec, traj)
-end
-
-function Base.:*(traj::NamedTrajectory, α::Float64)
-    return NamedTrajectory(α * traj.datavec, traj)
-end
-
-function Base.:+(traj1::NamedTrajectory, traj2::NamedTrajectory)
-    @assert traj1.names == traj2.names
-    @assert traj1.dim == traj2.dim
-    @assert traj1.T == traj2.T
-    return NamedTrajectory(traj1.datavec + traj2.datavec, traj1)
-end
-
-function Base.:-(traj1::NamedTrajectory, traj2::NamedTrajectory)
-    @assert traj1.names == traj2.names
-    @assert traj1.dim == traj2.dim
-    @assert traj1.T == traj2.T
-    return NamedTrajectory(traj1.datavec - traj2.datavec, traj1)
-end
 
 # -------------------------------------------------------------- #
 # Set/get methods
 # -------------------------------------------------------------- #
 
 """
-    get_components(::NamedTrajectory)
+    get_components(names, ::NamedTrajectory)
 
 Returns a NamedTuple containing the names and corresponding data matrices of the trajectory.
 """
@@ -764,57 +708,6 @@ end
 
 
 # =========================================================================== #
-
-@testitem "knot point methods" begin
-    include("../test/test_utils.jl")
-    fixed_time_traj = get_fixed_time_traj()
-    free_time_traj = get_free_time_traj()
-
-    # freetime
-    @test free_time_traj[1] isa KnotPoint
-    @test free_time_traj[1].x == free_time_traj.x[:, 1]
-    @test free_time_traj[end] isa KnotPoint
-    @test free_time_traj[end].x == free_time_traj.x[:, end]
-    @test free_time_traj[:x] == free_time_traj.x
-    @test free_time_traj.timestep isa Symbol
-
-    # fixed time
-    @test fixed_time_traj[1] isa KnotPoint
-    @test fixed_time_traj[1].x == fixed_time_traj.x[:, 1]
-    @test fixed_time_traj[end] isa KnotPoint
-    @test fixed_time_traj[end].x == fixed_time_traj.x[:, end]
-    @test fixed_time_traj[:x] == fixed_time_traj.x
-    @test fixed_time_traj.timestep isa Float64
-end
-
-@testitem "algebraic methods" begin
-    include("../test/test_utils.jl")
-    fixed_time_traj = get_fixed_time_traj()
-    free_time_traj = get_free_time_traj()
-    free_time_traj2 = copy(free_time_traj)
-    fixed_time_traj2 = copy(fixed_time_traj)
-
-    @test (free_time_traj + free_time_traj2).x == free_time_traj.x + free_time_traj2.x
-    @test (fixed_time_traj + fixed_time_traj2).x == fixed_time_traj.x + fixed_time_traj2.x
-
-    @test (free_time_traj - free_time_traj2).x == free_time_traj.x - free_time_traj2.x
-    @test (fixed_time_traj - fixed_time_traj2).x == fixed_time_traj.x - fixed_time_traj2.x
-
-    @test (2.0 * free_time_traj).x == (free_time_traj * 2.0).x == free_time_traj.x * 2.0
-    @test (2.0 * fixed_time_traj).x == (fixed_time_traj * 2.0).x == fixed_time_traj.x * 2.0
-end
-
-@testitem "copying and equality checks" begin
-    include("../test/test_utils.jl")
-    fixed_time_traj = get_fixed_time_traj()
-    free_time_traj = get_free_time_traj()
-
-    fixed_time_traj_copy = copy(fixed_time_traj)
-    free_time_traj_copy = copy(free_time_traj)
-
-    @test isequal(fixed_time_traj, fixed_time_traj_copy)
-    @test fixed_time_traj == fixed_time_traj_copy
-end
 
 @testitem "adding and removing state matrix and vector component" begin
     include("../test/test_utils.jl")

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -670,7 +670,8 @@ end
 end
 
 @testitem "remove component" begin
-    data = randn(5, 10)
+    T = 10
+    data = randn(5, T)
     traj = NamedTrajectory(data, (x = 1:3, y=4:4, z=5:5), timestep=:z)
     traj1 = remove_component(traj, :y)
     for name in [:x, :z]
@@ -679,10 +680,10 @@ end
     end
 
     # test removing timestep 
-    traj2 = remove_component(traj1, :z, new_timestep=:y)
+    traj2 = remove_component(traj, :z, new_timestep=:y)
     for name in [:x, :y]
         @test name ∈ traj2.names
-        @test traj2[name] == traj1[name]
+        @test traj2[name] == traj[name]
     end
     @test traj2.timestep == :y
 
@@ -699,9 +700,9 @@ end
         gdata=[1.0, 2.0], gcomponents=(g1=1:1, g2=2:2)
     )
     traj5 = remove_component(traj4, :g1)
-    @test :g1 ∉ traj4.gnames
+    @test :g1 ∉ traj5.gnames
     @test traj5.gdata == [2.0]
-    @test traj5.gcomponents == (g2=1:1)    
+    @test traj5.gcomponents == (g2 = 1:1,)    
 end
 
 @testitem "update! data" begin
@@ -736,7 +737,7 @@ end
     new_data = vcat(vec(orig_data), orig_gdata)
     update!(traj, new_data, type=:both)
     @test traj.data == orig_data
-    @test traj.gdata = orig_gdata
+    @test traj.gdata == orig_gdata
 end
 
 @testitem "update trajectory components via view" begin
@@ -798,9 +799,9 @@ end
 end
 
 @testitem "returning times" begin
-    data = randn(5, T)
+    data = randn(5, 10)
     traj = NamedTrajectory(data, (x=1:3, y=4:4, z=5:5), timestep=:z)
-    @test get_times(free_time_traj) ≈ [0.0, cumsum(data[end, 1:end-1])...]
+    @test get_times(traj) ≈ [0.0, cumsum(data[end, 1:end-1])...]
 end
 
 @testitem "suffix tests" begin

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -170,11 +170,9 @@ function add_components(
         end
         gcomps = merge(traj.global_components, gcomps_pairs)
 
-        println(typeof(global_data))
-
         return NamedTrajectory(
-            traj.datavec,
             traj; 
+            datavec=traj.datavec,
             global_data=global_data, 
             global_components=gcomps,
             kwargs...
@@ -205,8 +203,8 @@ function add_components(
         datavec = extend_datavec(traj.data, vcat(values(comps_data)...))
 
         return NamedTrajectory(
-            datavec,
             traj;
+            datavec=datavec,
             components=comps,
             controls=controls,
             kwargs...

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -1,5 +1,8 @@
 module MethodsNamedTrajectory
 
+# Does it make sense to have a mutation?
+# - Yes for data, No for shapes.
+
 export vec
 export get_components
 export get_component_names
@@ -24,6 +27,12 @@ using TestItems
 
 using ..StructNamedTrajectory
 using ..StructKnotPoint
+
+# -------------------------------------------------------------- #
+# Base show
+# -------------------------------------------------------------- #
+
+Base.show(io::IO, traj::NamedTrajectory) = print(io, traj.components, ", T = ", traj.T)
 
 # -------------------------------------------------------------- #
 # Base indexing
@@ -81,7 +90,9 @@ Base.getindex(traj::NamedTrajectory, symb::Symbol) = getproperty(traj, symb)
 Returns the component of the trajectory with name `symb` (as a view) or the property of the trajectory with name `symb`.
 """
 function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
-    if symb ∈ fieldnames(NamedTrajectory)
+    if symb == :data
+        return reshape(view(traj.datavec, :), :, traj.T)
+    elseif symb ∈ fieldnames(NamedTrajectory)
         return getfield(traj, symb)
     else
         indices = traj.components[symb]

--- a/src/random_trajectories.jl
+++ b/src/random_trajectories.jl
@@ -31,13 +31,16 @@ function Base.rand(
     state_dim::Int=3,
     control_dim::Int=2
 )
-    data = (
+    comps_data = (;
         state => randn(state_dim, T),
         control => randn(control_dim, T),
-        timestep => fill(timestep_value, T)
+        timestep => fill(timestep_value, 1, T)
     )
 
-    return NamedTrajectory(data; timestep=timestep, controls=(control, timestep))
+    return NamedTrajectory(
+        comps_data, NamedTuple(); 
+        timestep=timestep, controls=(control, timestep)
+    )
 end
 
 # =========================================================================== #

--- a/src/random_trajectories.jl
+++ b/src/random_trajectories.jl
@@ -25,31 +25,26 @@ function Base.rand(
     ::Type{NamedTrajectory},
     T::Int;
     timestep_value::Float64=1.0,
-    timestep_name::Symbol=:Δt,
-    free_time::Bool=false,
-    timestep::Union{Float64,Symbol}=free_time ? timestep_name : timestep_value,
+    timestep::Symbol=:Δt,
+    state::Symbol=:x,
+    control::Symbol=:u,
     state_dim::Int=3,
     control_dim::Int=2
 )
     data = (
-        x = randn(state_dim, T),
-        u = randn(control_dim, T)
+        state => randn(state_dim, T),
+        control => randn(control_dim, T),
+        timestep => fill(timestep_value, T)
     )
 
-    if timestep isa Symbol
-        data = merge(data, NamedTuple((timestep => fill(timestep_value, T),)))
-    end
-
-    return NamedTrajectory(data; timestep=timestep, controls=:u)
+    return NamedTrajectory(data; timestep=timestep, controls=(control, timestep))
 end
 
 # =========================================================================== #
 
 @testitem "random trajectories" begin
     @test rand(NamedTrajectory, 5) isa NamedTrajectory
-    @test rand(NamedTrajectory, 5; timestep=0.1).timestep == 0.1
     @test rand(NamedTrajectory, 5; timestep=:dt).timestep == :dt
-    @test rand(NamedTrajectory, 5; free_time=true).timestep isa Symbol
 end
 
 end

--- a/src/random_trajectories.jl
+++ b/src/random_trajectories.jl
@@ -37,10 +37,7 @@ function Base.rand(
         timestep => fill(timestep_value, 1, T)
     )
 
-    return NamedTrajectory(
-        comps_data, NamedTuple(); 
-        timestep=timestep, controls=(control, timestep)
-    )
+    return NamedTrajectory(comps_data;  timestep=timestep, controls=(control, timestep))
 end
 
 # =========================================================================== #

--- a/src/struct_knot_point.jl
+++ b/src/struct_knot_point.jl
@@ -4,6 +4,8 @@ export KnotPoint
 
 using ..StructNamedTrajectory
 
+# TODO: Concerete type
+
 """
     KnotPoint constructor
 """

--- a/src/struct_knot_point.jl
+++ b/src/struct_knot_point.jl
@@ -4,20 +4,21 @@ export KnotPoint
 
 using ..StructNamedTrajectory
 
-# TODO: Concerete type
-
 """
     KnotPoint constructor
 """
-struct KnotPoint
+struct KnotPoint{
+    R <: Real,
+    CNames, CTypes <: StructNamedTrajectory.ComponentType,
+    N <: Tuple{Vararg{Symbol}},
+    CN <: Tuple{Vararg{Symbol}}
+}
     t::Int
-    data::AbstractVector{Float64}
-    timestep::Float64
-    components::NamedTuple{
-        cnames, <:Tuple{Vararg{AbstractVector{Int}}}
-    } where cnames
-    names::Tuple{Vararg{Symbol}}
-    control_names::Tuple{Vararg{Symbol}}
+    data::AbstractVector{R}
+    timestep::R
+    components::NamedTuple{CNames, CTypes}
+    names::N
+    control_names::CN
 end
 
 end

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -27,7 +27,8 @@ dimensions, initial and final conditions, goal states, and components.
 This struct is designed to hold trajectory data in a named format, allowing for easy access 
 to knot points by `Symbol`.
 
-NamedTrajectory is designed to make allocation-free access easy to write.
+NamedTrajectory is designed to make allocation-free access easy to write. The data
+can be updated after construction, but the fields cannot.
 """
 mutable struct NamedTrajectory{
     R <: Real,

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -8,6 +8,298 @@ using TestItems
 
 const BoundType = Tuple{AbstractVector{<:Real}, AbstractVector{<:Real}}
 
+# UnitRange{Int} enforces nonallocating @views with indexing
+const ComponentType = Tuple{Vararg{UnitRange{Int}}}
+
+# TODO: Can we fix these NamedTuple types at a higher level?
+
+# ---------------------------------------------------------------------------- #
+# Named Trajectory
+# ---------------------------------------------------------------------------- #
+
+"""
+    NamedTrajectory
+
+Container for trajectory optimization problems, which includes the trajectory data, bounds,
+dimensions, initial and final conditions, goal states, and components.
+
+This struct is designed to hold trajectory data in a named format, allowing for easy access 
+to knot points by `Symbol`.
+
+NamedTrajectory is designed to make allocation-free access easy to write.
+"""
+mutable struct NamedTrajectory{
+    R <: Real,
+    DNames, DTypes <: Tuple,
+    BNames, BTypes <: Tuple,
+    INames, ITypes <: Tuple,
+    FNames, FTypes <: Tuple,
+    GNames, GTypes <: Tuple,
+    CNames, CTypes <: ComponentType,
+    N <: Tuple,
+    SN <: Tuple,
+    CN <: Tuple,
+    GDNames, GDTypes <: Tuple,
+    GCNames, GCTypes <: ComponentType,
+    GN <: Tuple,
+}
+    datavec::Vector{R}
+    T::Int
+    timestep::Symbol
+    dim::Int
+    dims::NamedTuple{DNames, DTypes}
+    bounds::NamedTuple{BNames, BTypes}
+    initial::NamedTuple{INames, ITypes}
+    final::NamedTuple{FNames, FTypes}
+    goal::NamedTuple{GNames, GTypes}
+    components::NamedTuple{CNames, CTypes}
+    names::N
+    state_names::SN
+    control_names::CN
+    gdata::Vector{R}
+    gdim::Int
+    gdims::NamedTuple{GDNames, GDTypes}
+    gcomponents::NamedTuple{GCNames, GCTypes}
+    gnames::GN
+end
+
+"""
+    NamedTrajectory(datavec, components, T)
+
+Construct a named trajectory from a data vector, components, and knot points.
+"""
+function NamedTrajectory(
+    datavec::AbstractVector{R},
+    comps::NamedTuple{N, <:ComponentType} where N,
+    T::Int;
+    timestep::Symbol=:Δt,
+    controls::Union{Symbol, Tuple{Vararg{Symbol}}}=timestep,
+    bounds=NamedTuple(),
+    initial=NamedTuple(),
+    final=NamedTuple(),
+    goal=NamedTuple(),
+    gdata::AbstractVector{R}=R[],
+    gcomps::NamedTuple{GN, <:ComponentType} where GN=NamedTuple(),
+) where R <: Real
+    @assert :data ∉ keys(comps) "data is a reserved name"
+
+    @assert timestep isa Symbol && timestep ∈ keys(comps)
+
+    controls = controls isa Symbol ? (controls,) : controls
+
+    # timestep is a control
+    if timestep isa Symbol && !in(timestep, controls)
+        controls = (controls..., timestep)
+    end
+    
+    names = Tuple(keys(comps))
+    inspect_names(names, controls, keys(initial), keys(final), keys(goal), keys(bounds))
+    states = Tuple(k for k ∈ names if k ∉ controls)
+
+    # save data matrix as view of datavec
+    data = reshape(view(datavec, :), :, T)
+    dim = size(data, 1)
+
+    # save dims
+    dims_pairs = [(k => length(v)) for (k, v) ∈ pairs(comps)]
+    dims = NamedTuple(dims_pairs)
+
+    # process and save bounds
+    bounds = get_bounds_from_dims(bounds, dims)
+
+    # check data
+    inspect_dims_pairs(dims_pairs, bounds, initial, final, goal)
+
+    # global data 
+    gdim = length(gdata)
+    gdims = NamedTuple([(k => length(v)) for (k, v) ∈ pairs(gcomps)])
+    gnames = Tuple(keys(gcomps))
+
+    # check global data
+    @assert gdim == sum(values(gdims), init=0) "invalid global data dims"
+
+    return NamedTrajectory(
+        datavec,
+        T,
+        timestep,
+        dim,
+        dims,
+        bounds,
+        initial,
+        final,
+        goal,
+        comps,
+        names,
+        states,
+        controls,
+        gdata,
+        gdim,
+        gdims,
+        gcomps,
+        gnames
+    )
+end
+
+"""
+    NamedTrajectory(component_data, gcomponents_data)
+
+Construct a `NamedTrajectory` from component data and global component data
+"""
+function NamedTrajectory(
+    comps_data::NamedTuple{N, <:Tuple{Vararg{AbstractMatrix{R}}}} where N,
+    gcomps_data::NamedTuple{GN, <:Tuple{Vararg{AbstractVector{R}}}} where GN;
+    kwargs...
+) where R <: Real
+    # unpack data
+    data = vcat([val for (key, val) ∈ pairs(comps_data)]...)
+    dim, T = size(data)
+
+    # save components of data matrix
+    dims_pairs = [(k => size(v, 1)) for (k, v) ∈ pairs(comps_data)]
+    comps_pairs = [(dims_pairs[1][1] => 1:dims_pairs[1][2])]
+    for (k, dim) in dims_pairs[2:end]
+        k_range = comps_pairs[end][2][end] .+ (1:dim)
+        push!(comps_pairs, k => k_range)
+    end
+    comps = NamedTuple(comps_pairs)
+
+    # unpack global data
+    gdata = vcat([val for (key, val) ∈ pairs(gcomps_data)]...)
+
+    # save global componets
+    if !isempty(gcomps_data)
+        gdims_pairs = [(k => length(v)) for (k, v) ∈ pairs(gcomps_data)]
+        gcomps_pairs = [(gdims_pairs[1][1] => 1:gdims_pairs[1][2])]
+        for (k, v) ∈ gdims_pairs[2:end]
+            # offset within gdata
+            k_value = gcomps_pairs[end][2][end] .+ (1:v)
+            push!(gcomps_pairs, k => k_value)
+        end
+        gcomps = NamedTuple(gcomps_pairs)
+
+        return NamedTrajectory(
+            vec(data), comps, T; 
+            gdata=gdata, gcomps=gcomps, kwargs...
+        )
+    else
+        return NamedTrajectory(vec(data), comps, T; kwargs...)
+    end
+end
+
+"""
+    NamedTrajectory(component_data)
+
+Construct a `NamedTrajectory` from component data.
+"""
+function NamedTrajectory(
+    comps_data::NamedTuple{N, <:Tuple{Vararg{AbstractMatrix{R}}}} where N;
+    kwargs...
+) where R <: Real
+    return NamedTrajectory(
+        comps_data,
+        NamedTuple();
+        kwargs...
+    )
+end
+
+"""
+    NamedTrajectory(component_data::NamedTuple, timestep; kwargs...)
+
+Construct a `NamedTrajectory` from mixed Matrix/Vector component data.
+"""
+function NamedTrajectory(
+    comps_data::NamedTuple;
+    kwargs...
+)
+    @assert all([v isa AbstractMatrix || v isa AbstractVector for v ∈ values(comps_data)])
+    vals = [v isa AbstractVector ? reshape(v, 1, :) : v for v ∈ values(comps_data)]
+    comps_data = NamedTuple([(k => v) for (k, v) ∈ zip(keys(comps_data), vals)])
+    return NamedTrajectory(comps_data, timestep; kwargs...)
+end
+
+"""
+    NamedTrajectory(data, traj)
+
+Construct a `NamedTrajectory` from a datavec and an existing `NamedTrajectory`.
+"""
+function NamedTrajectory(
+    datavec::AbstractVector{R},
+    traj::NamedTrajectory;    
+    gdata::AbstractVector{R}=traj.gdata,
+) where R <: Real
+    @assert length(datavec) == length(traj.datavec)
+    @assert length(gdata) == length(traj.gdata)
+
+    return NamedTrajectory(
+        datavec,
+        traj.components,
+        traj.T;
+        timestep=traj.timestep,
+        controls=traj.control_names,
+        bounds=traj.bounds,
+        initial=traj.initial,
+        final=traj.final,
+        goal=traj.goal,
+        gdata=gdata,
+        gdim=traj.gdim,
+        gdims=traj.gdims,
+        gcomponents=traj.gcomponents,
+        gnames=traj.gnames
+    )
+end
+
+"""
+    NamedTrajectory(data, components; kwargs...)
+
+Construct a `NamedTrajectory` from a data matrix and components.
+"""
+function NamedTrajectory(
+    data::AbstractMatrix{R},
+    comps::NamedTuple{N, <:ComponentType} where N;
+    kwargs...
+) where R <: Real
+    T = size(data, 2)
+    datavec = vec(data)
+    return NamedTrajectory(datavec, comps, T; kwargs...)
+end
+
+# ----------------------------------------------------------------------------- #
+# Named trajectory data processing
+# ----------------------------------------------------------------------------- #
+
+function get_bounds_from_dims(
+    bounds::NamedTuple,
+    dims::NamedTuple{N, <:Tuple{Vararg{Int}}} where N,
+)
+    @assert all([
+        bound isa Real ||
+        bound isa AbstractVector{<:Real} ||
+        bound isa Tuple{<:Real, <:Real} ||
+        bound isa BoundType
+            for bound ∈ bounds
+    ])
+
+    bounds_dict = OrderedDict{Symbol,Any}(pairs(bounds))
+    for (name, bound) ∈ bounds_dict
+        if bound isa Real
+            bounds_dict[name] = (
+                -fill(bound, size(dims[name], 1)),
+                fill(bound, size(dims[name], 1))
+            )
+        elseif bound isa AbstractVector
+            bounds_dict[name] = (-bound, bound)
+        elseif bound isa Tuple{<:Real, <:Real}
+            bounds_dict[name] = ([bound[1]], [bound[2]])
+        end
+    end
+    return NamedTuple(bounds_dict)
+end
+
+"""
+    inspect_names(names, controls, initial, final, goal, bounds)
+
+Check for missing names in the trajectory components.
+"""
 function inspect_names(
     names::Tuple{Vararg{Symbol}},
     controls::Tuple{Vararg{Symbol}},
@@ -33,12 +325,17 @@ function inspect_names(
     end
 end
 
+"""
+    inspect_dims_pairs(dims_pairs, bounds, initial, final, goal)
+
+Check for proper formatting of trajectory components.
+"""
 function inspect_dims_pairs(
     dims_pairs::Vector{Pair{Symbol, Int}},
-    bounds::NamedTuple{bnames, <:Tuple{Vararg{BoundType}}} where bnames,
-    initial::NamedTuple{inames, <:Tuple{Vararg{AbstractVector{R}}}} where inames,
-    final::NamedTuple{fnames, <:Tuple{Vararg{AbstractVector{R}}}} where fnames,
-    goal::NamedTuple{gnames, <:Tuple{Vararg{AbstractVector{R}}}} where gnames
+    bounds::NamedTuple{bname, <:Tuple{Vararg{BoundType}}} where bname,
+    initial::NamedTuple{iname, <:Tuple{Vararg{AbstractVector{R}}}} where iname,
+    final::NamedTuple{fname, <:Tuple{Vararg{AbstractVector{R}}}} where fname,
+    goal::NamedTuple{gname, <:Tuple{Vararg{AbstractVector{R}}}} where gname
 ) where R <: Real
     dims_tuple = NamedTuple(dims_pairs)
     for k in keys(bounds)
@@ -55,504 +352,74 @@ function inspect_dims_pairs(
     end
 end
 
-"""
-    NamedTrajectory constructor
-"""
-mutable struct NamedTrajectory{R <: Real}
-    data::AbstractMatrix{R}
-    datavec::AbstractVector{R}
-    T::Int
-    timestep::Union{Symbol,R}
-    dim::Int
-    dims::NamedTuple{dnames, <:Tuple{Vararg{Int}}} where dnames
-    bounds::NamedTuple{bnames, <:Tuple{Vararg{BoundType}}} where bnames
-    initial::NamedTuple{inames, <:Tuple{Vararg{AbstractVector{R}}}} where inames
-    final::NamedTuple{fnames, <:Tuple{Vararg{AbstractVector{R}}}} where fnames
-    goal::NamedTuple{gnames, <:Tuple{Vararg{AbstractVector{R}}}} where gnames
-    components::NamedTuple{cnames, <:Tuple{Vararg{AbstractVector{Int}}}} where cnames
-    global_data::NamedTuple{pnames, <:Tuple{Vararg{AbstractVector{R}}}} where pnames
-    global_dim::Int
-    global_dims::NamedTuple{gdnames, <:Tuple{Vararg{Int}}} where gdnames
-    global_components::NamedTuple{gcnames, <:Tuple{Vararg{AbstractVector{Int}}}} where gcnames
-    names::Tuple{Vararg{Symbol}}
-    state_names::Tuple{Vararg{Symbol}}
-    control_names::Tuple{Vararg{Symbol}}
-end
-
-"""
-    NamedTrajectory(component_data; controls=(), timestep=nothing, bounds, initial, final, goal)
-
-    # Arguments
-    - `component_data::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where {names}`: Components data.
-    - `controls`: The control variable in component_data, should be type of `Symbol` among `component_data`.
-    - `timestep`: Discretizing time step in `component_data`, should be type of `Symbol` among `component_data`.
-    - `bounds`: Bounds of the trajectory.
-    - `initial`: Initial values.
-    - `final`: Final values.
-    - `goal`: Goal for the states.
-"""
-function NamedTrajectory(
-    component_data::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where {names};
-    controls::Union{Symbol, Tuple{Vararg{Symbol}}}=(),
-    timestep::Union{Nothing,Symbol,R}=nothing,
-    bounds=(;),
-    initial=(;),
-    final=(;),
-    goal=(;),
-    global_data=(;),
-) where R <: Real
-    controls = controls isa Symbol ? (controls,) : controls
-
-    @assert !isempty(controls)
-    @assert !isnothing(timestep)
-    @assert timestep isa Symbol && timestep ∈ keys(component_data) ||
-        timestep isa Real "timestep $(timestep)::$(typeof(timestep)) must be a symbol or real"
-    
-    names = Tuple(keys(component_data))
-    inspect_names(names, controls, keys(initial), keys(final), keys(goal), keys(bounds))
-
-    @assert all([
-        bound isa Real ||
-        bound isa AbstractVector{<:Real} ||
-        bound isa Tuple{<:Real,<:Real} ||
-        bound isa BoundType
-            for bound ∈ bounds
-    ])
-
-    if timestep isa Symbol && !in(timestep, controls)
-        controls = (controls..., timestep)
-    end
-
-
-    state_names = Tuple(k for k ∈ names if k ∉ controls)
-
-    bounds_dict = OrderedDict{Symbol,Any}(pairs(bounds))
-
-    for (name, bound) ∈ bounds_dict
-        if bound isa Real
-            bounds_dict[name] = (
-                -fill(bound, size(component_data[name], 1)),
-                fill(bound, size(component_data[name], 1))
-            )
-        elseif bound isa AbstractVector
-            bounds_dict[name] = (-bound, bound)
-        elseif bound isa Tuple{<:Real, <:Real}
-            bounds_dict[name] = ([bound[1]], [bound[2]])
-        end
-    end
-    bounds = NamedTuple(bounds_dict)
-
-    component_data_pairs = []
-    for (key, val) ∈ pairs(component_data)
-        if val isa AbstractVector{<:Real}
-            data = reshape(val, 1, :)
-            push!(component_data_pairs, key => data)
-        else
-            push!(component_data_pairs, key => val)
-        end
-    end
-
-    data = vcat([val for (key, val) ∈ component_data_pairs]...)
-    dim, T = size(data)
-
-    # store data matrix as view of datavec
-    datavec = vec(data)
-    data = reshape(view(datavec, :), :, T)
-
-    dims_pairs = [(k => size(v, 1)) for (k, v) ∈ component_data_pairs]
-    inspect_dims_pairs(dims_pairs, bounds, initial, final, goal)
-
-    comp_pairs::Vector{Pair{Symbol, AbstractVector{Int}}} =
-        [(dims_pairs[1][1] => 1:dims_pairs[1][2])]
-
-    for (k, dim) in dims_pairs[2:end]
-        k_range = comp_pairs[end][2][end] .+ (1:dim)
-        push!(comp_pairs, k => k_range)
-    end
-
-    # add states and controls to dims
-
-    dim_states = sum([dim for (k, dim) in dims_pairs if k ∉ controls])
-    dim_controls = sum([dim for (k, dim) in dims_pairs if k ∈ controls])
-
-    push!(dims_pairs, :states => dim_states)
-    push!(dims_pairs, :controls => dim_controls)
-
-    dims = NamedTuple(dims_pairs)
-
-    # add states and controls to components
-
-    temp_comp_tuple = NamedTuple(comp_pairs)
-    states_comps = vcat([temp_comp_tuple[k] for k ∈ keys(component_data) if k ∉ controls]...)
-    controls_comps = vcat([temp_comp_tuple[k] for k ∈ keys(component_data) if k ∈ controls]...)
-
-    push!(comp_pairs, :states => states_comps)
-    push!(comp_pairs, :controls => controls_comps)
-
-    comps = NamedTuple(comp_pairs)
-
-    # global dims
-
-    global_dims_pairs = [(k => length(v)) for (k, v) ∈ pairs(global_data)]
-    global_comps_pairs::Vector{Pair{Symbol, AbstractVector{Int}}} = []
-    
-    running_global_dim = 0
-    for (k, v) ∈ global_dims_pairs
-        # offset by datavec
-        k_value = (dim * T + running_global_dim) .+ (1:v)
-        push!(global_comps_pairs, k => k_value)
-        running_global_dim += v
-    end
-
-    global_comps = NamedTuple(global_comps_pairs)
-    global_dims = NamedTuple(global_dims_pairs)
-    global_dim = sum(values(global_dims), init=0)
-
-    return NamedTrajectory{R}(
-        data,
-        datavec,
-        T,
-        timestep,
-        dim,
-        dims,
-        bounds,
-        initial,
-        final,
-        goal,
-        comps,
-        global_data,
-        global_dim,
-        global_dims,
-        global_comps,
-        names,
-        state_names,
-        controls
-    )
-end
-
-"""
-    NamedTrajectory(component_data; kwargs...)
-
-    # Arguments
-    - `component_data::NamedTuple`: Components data. Values should be of type `Union{AbstractVector{<:Real}, AbstractMatrix{<:Real}}`.
-    - `kwargs...`: The other key word arguments.
-"""
-function NamedTrajectory(
-    component_data::NamedTuple;
-    kwargs...
-)
-    @assert all([v isa AbstractMatrix || v isa AbstractVector for v ∈ values(component_data)])
-    @assert all([eltype(v) <: Real for v ∈ values(component_data)]) "eltypes are $([eltype(v) for v ∈ values(component_data)])"
-    vals = [v isa AbstractVector ? reshape(v, 1, :) : v for v ∈ values(component_data)]
-    component_data = NamedTuple([(k => v) for (k, v) ∈ zip(keys(component_data), vals)])
-    return NamedTrajectory(component_data; kwargs...)
-end
-
-
-
-
-"""
-    NamedTrajectory(datavec, T, components)
-
-"""
-function NamedTrajectory(
-    datavec::AbstractVector{R},
-    T::Int,
-    components::NamedTuple{
-        names,
-        <:Tuple{Vararg{AbstractVector{Int}}}
-    } where names;
-    timestep::Union{Nothing,Symbol,R}=nothing,
-    controls::Union{Symbol, Tuple{Vararg{Symbol}}}=(),
-    bounds=(;),
-    initial=(;),
-    final=(;),
-    goal=(;),
-    global_data=(;),
-) where R <: Real
-    controls = (controls isa Symbol) ? (controls,) : controls
-
-    @assert !isempty(controls) "must specify at least one control"
-    @assert !isnothing(timestep) "must specify a time step size"
-    @assert timestep isa Symbol && timestep ∈ keys(components) ||
-        timestep isa Real
-
-    names = Tuple(keys(components))
-    inspect_names(names, controls, keys(initial), keys(final), keys(goal), keys(bounds))
-
-    @assert all([
-        (bound isa Real) ||
-        (bound isa AbstractVector{<:Real}) ||
-        (bound isa Tuple{<:Real,<:Real}) ||
-        (bound isa BoundType)
-        for bound ∈ bounds
-    ])
-    if timestep isa Symbol && !in(timestep, controls)
-        controls = (controls..., timestep)
-    end
-
-    bounds_dict = OrderedDict(pairs(bounds))
-    for (name, bound) ∈ bounds_dict
-        if bound isa AbstractVector
-            bounds_dict[name] = (-bound, bound)
-        end
-    end
-    bounds = NamedTuple(bounds_dict)
-
-    data = reshape(view(datavec, :), :, T)
-    dim = size(data, 1)
-
-    @assert all([isa(components[k], AbstractVector{Int}) for k in keys(components)])
-    @assert vcat([components[k] for k in keys(components)]...) == 1:dim
-
-    dim_pairs = [(k => length(components[k])) for k in keys(components)]
-    inspect_dims_pairs(dims_pairs, bounds, initial, final, goal)
-
-    dim_states = sum([dim for (k, dim) ∈ dim_pairs if k ∉ controls])
-    dim_controls = sum([dim for (k, dim) ∈ dim_pairs if k ∈ controls])
-
-    push!(dim_pairs, :states => dim_states)
-    push!(dim_pairs, :controls => dim_controls)
-
-    dims = NamedTuple(dim_pairs)
-
-    state_names = Tuple(k for k ∈ names if k ∉ controls)
-
-    # global dims
-    
-    global_dims_pairs = [(k => length(v)) for (k, v) ∈ pairs(global_data)]
-    global_comps_pairs::Vector{Pair{Symbol, AbstractVector{Int}}} = []
-    
-    running_global_dim = 0
-    for (k, v) ∈ global_dims_pairs
-        # offset by datavec
-        push!(global_comps_pairs, k => (dim * T + running_global_dim) .+ 1:v)
-        running_global_dim += v
-    end
-
-    global_comps = NamedTuple(global_comps_pairs)
-    global_dims = NamedTuple(global_dims_pairs)
-    global_dim = sum(values(global_dims), init=0)
-
-    return NamedTrajectory{R}(
-        data,
-        datavec,
-        T,
-        timestep,
-        dim,
-        dims,
-        bounds,
-        initial,
-        final,
-        goal,
-        components,
-        global_data,
-        global_dim,
-        global_dims,
-        global_comps,
-        names,
-        state_names,
-        controls
-    )
-end
-
-"""
-    NamedTrajectory(component_data; controls=(), timestep=nothing, bounds, initial, final, goal)
-
-    # Arguments
-    - `datavec::AbstractVector{R} where R <: Real`: Trajectory data.
-    - `traj`: Constructed `NamedTrajectory`.
-"""
-function NamedTrajectory(
-    datavec::AbstractVector{R},
-    traj::NamedTrajectory
-) where R <: Real
-    return NamedTrajectory(
-        datavec,
-        traj.global_data,
-        traj
-    )
-end
-
-function NamedTrajectory(
-    datavec::AbstractVector{R},
-    global_data::NamedTuple{pnames, <:Tuple{Vararg{AbstractVector{R}}}} where pnames,
-    traj::NamedTrajectory
-) where R <: Real
-    @assert length(datavec) == length(traj.datavec)
-    for (k, v) ∈ pairs(global_data)
-        @assert length(v) == traj.global_dims[k] "$k: $(length(v)) != $(traj.global_dims[k])"
-    end
-
-    # collecting here to prevent overlapping views
-    # TODO: is this necessary?
-    datavec = collect(datavec)
-
-    data = reshape(view(datavec, :), :, traj.T)
-
-    return NamedTrajectory{R}(
-        data,
-        datavec,
-        traj.T,
-        traj.timestep,
-        traj.dim,
-        traj.dims,
-        traj.bounds,
-        traj.initial,
-        traj.final,
-        traj.goal,
-        traj.components,
-        global_data,
-        traj.global_dim,
-        traj.global_dims,
-        traj.global_components,
-        traj.names,
-        traj.state_names,
-        traj.control_names
-    )
-end
-
-"""
-    NamedTrajectory(data, traj)
-
-    # Arguments
-    - `data`: Trajectory data.
-    - `traj`: Constructed `NamedTrajectory`.
-"""
-function NamedTrajectory(
-    data::AbstractMatrix{R},
-    traj::NamedTrajectory
-) where R <: Real
-    @assert size(data) == size(traj.data)
-
-    # collecting here to prevent overlapping views
-    # TODO: is this necessary?
-    datavec = vec(collect(data))
-
-    data = reshape(view(datavec, :), :, traj.T)
-
-    return NamedTrajectory{R}(
-        data,
-        datavec,
-        traj.T,
-        traj.timestep,
-        traj.dim,
-        traj.dims,
-        traj.bounds,
-        traj.initial,
-        traj.final,
-        traj.goal,
-        traj.components,
-        traj.global_data,
-        traj.global_dim,
-        traj.global_dims,
-        traj.global_components,
-        traj.names,
-        traj.state_names,
-        traj.control_names
-    )
-end
-
-"""
-    NamedTrajectory(data, components; kwargs...)
-
-    # Arguments
-    - `data::AbstractMatrix{R}`: Trajectory data.
-    - `components::NamedTuple{names, <:Tuple{Vararg{AbstractVector{Int}}}} where names`: components data.
-    - `kwargs...` : The other key word arguments.
-"""
-function NamedTrajectory(
-    data::AbstractMatrix{R},
-    components::NamedTuple{
-        names,
-        <:Tuple{Vararg{AbstractVector{Int}}}
-    } where names;
-    kwargs...
-) where R <: Real
-    T = size(data, 2)
-    datavec = vec(data)
-    return NamedTrajectory(datavec, T, components; kwargs...)
-end
-
-"""
-    NamedTrajectory(component_data; controls=(), timestep=nothing, bounds, initial, final, goal)
-
-    # Arguments
-    - `comps::NamedTuple{names, <:Tuple{Vararg{AbstractMatrix{R}}}} where {names}`: components data.
-    - `traj`: Constructed NamedTrajectory.
-    - `goal`: Goal for the states.
-"""
-function NamedTrajectory(
-    comps::NamedTuple{
-        names,
-        <:Tuple{Vararg{AbstractMatrix{R}}}
-    } where names,
-    traj::NamedTrajectory;
-    new_timestep::Union{Nothing, R}=nothing,
-    new_control_names::Tuple{Vararg{Symbol}}=()
-) where R <: Real
-    @assert all([k ∈ traj.names for k ∈ keys(comps)])
-
-    control_names = (
-        [name for name ∈ traj.control_names if name ∈ keys(comps) && name ∉ new_control_names]...,
-        new_control_names...
-    )
-    @assert !isempty(control_names) "must specify at least one control"
-
-    if traj.timestep isa Symbol && isnothing(new_timestep)
-        @assert traj.timestep ∈ keys(comps) "timestep symbol must be in components"
-    end
-
-    bounds = NamedTuple([(k => traj.bounds[k]) for k ∈ keys(comps) if k ∈ keys(traj.bounds)])
-    initial = NamedTuple([(k => traj.initial[k]) for k ∈ keys(comps) if k ∈ keys(traj.initial)])
-    final = NamedTuple([(k => traj.final[k]) for k ∈ keys(comps) if k ∈ keys(traj.final)])
-    goal = NamedTuple([(k => traj.goal[k]) for k ∈ keys(comps) if k ∈ keys(traj.goal)])
-    # global comps are separate from comps
-    global_data = deepcopy(traj.global_data)
-
-    return NamedTrajectory(
-        comps;
-        controls=control_names,
-        timestep=isnothing(new_timestep) ? traj.timestep : new_timestep,
-        bounds=bounds,
-        initial=initial,
-        final=final,
-        goal=goal,
-        global_data=global_data,
-    )
-
-end
-
 # =========================================================================== #
 
-@testitem "testing constructor" begin
+@testitem "Construct from data matrix and comps" begin
+    n = 5
+    T = 10
+    data = randn(n, T)
+    traj = NamedTrajectory(data, (x = 1:3, y=4:4, z=5:5))
+    @test traj.data ≈ data
+    @test traj.timestep == :Δt
+    @test traj.dim == n
+    @test traj.T == T
+
+    traj = NamedTrajectory(data, (x = 1:3, y=4:4, z=5:5), timestep=:z)
+    @test traj.data ≈ data
+    @test traj.timestep == :z
+    @test traj.dim == n
+    @test traj.T == T
+end
+
+@testitem "Construct from component data" begin
     # define number of timesteps and timestep
     T = 10
     dt = 0.1
 
-    components = (
-    x = rand(3, T),
-    u = rand(2, T),
-    Δt = fill(dt, 1, T),
+    dim = 6
+    comps_data = (
+        x = rand(3, T),
+        u = rand(2, T),
+        Δt = fill(dt, 1, T),
     )
 
-    timestep = 0.1
+    timestep = :Δt
     control = :u
 
     # some global params as a NamedTuple
-    params = (
+    gdim = 2
+    gcomps_data = (
         α = rand(1),
         β = rand(1)
     )
 
     traj = NamedTrajectory(
-        components; 
+        comps_data,
+        gcomps_data;
         timestep=timestep, 
-        controls=control, 
-        global_data=params
+        controls=control
     )
 
-    @test traj.global_data == params
+    @test traj.T == T
+    @test traj.dim == dim
+    @test length(traj.gdata) == gdim
+
+    comps_res = NamedTuple([(k => traj.data[v, :]) for (k, v) in pairs(traj.components)]) 
+    @test comps_res == comps_data
+
+    gres = NamedTuple([(k => traj.gdata[v]) for (k, v) in pairs(traj.gcomponents)])
+    @test gres == gcomps_data
+
+    # ignore global
+    traj = NamedTrajectory(comps_data)
+
+    @test traj.T == T
+    @test traj.dim == dim
+
+    comps_res = NamedTuple([(k => traj.data[v, :]) for (k, v) in pairs(traj.components)]) 
+    @test comps_res == comps_data
+
+    @test isempty(traj.gdata)
 end
 
 

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -226,24 +226,33 @@ Construct a `NamedTrajectory` from a datavec and an existing `NamedTrajectory`.
 """
 function NamedTrajectory(
     datavec::AbstractVector{R},
-    traj::NamedTrajectory;    
+    traj::NamedTrajectory;
+    components::NamedTuple{N, <:ComponentType} where N=traj.components,
+    T::Int=traj.T,
+    timestep::Symbol=traj.timestep,
+    controls::Union{Symbol, Tuple{Vararg{Symbol}}}=traj.control_names,
+    bounds=traj.bounds,
+    initial=traj.initial,
+    final=traj.final,
+    goal=traj.goal,
     gdata::AbstractVector{R}=traj.gdata,
+    gcomponents::NamedTuple{GN, <:ComponentType} where GN=traj.gcomponents,
 ) where R <: Real
-    @assert length(datavec) == length(traj.datavec)
-    @assert length(gdata) == length(traj.gdata)
+    @assert length(datavec) == sum(length.(values(components)), init=0) * T "Data vector length does not match components * T"
+    @assert length(gdata) == sum(length.(values(gcomponents)), init=0) "Global data length does not match global components"
 
     return NamedTrajectory(
         datavec,
-        traj.components,
-        traj.T;
-        timestep=traj.timestep,
-        controls=traj.control_names,
-        bounds=traj.bounds,
-        initial=traj.initial,
-        final=traj.final,
-        goal=traj.goal,
+        components,
+        T;
+        timestep=timestep,
+        controls=controls,
+        bounds=bounds,
+        initial=initial,
+        final=final,
+        goal=goal,
         gdata=gdata,
-        gcomponents=traj.gcomponents,
+        gcomponents=gcomponents,
     )
 end
 

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -85,7 +85,7 @@ function NamedTrajectory(
     @assert :data ∉ keys(comps) "data is a reserved name"
     @assert isdisjoint(keys(comps), keys(gcomponents)) "components and global components should use unique names"
 
-    @assert timestep isa Symbol && timestep ∈ keys(comps)
+    @assert timestep isa Symbol && timestep ∈ keys(comps) "Missing timestep in components"
 
     controls = controls isa Symbol ? (controls,) : controls
 
@@ -181,7 +181,7 @@ function NamedTrajectory(
 
         return NamedTrajectory(
             vec(data), comps, T; 
-            gdata=gdata, gcomps=gcomps, kwargs...
+            gdata=gdata, gcomponents=gcomps, kwargs...
         )
     else
         return NamedTrajectory(vec(data), comps, T; kwargs...)

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -14,7 +14,6 @@ const ComponentType = Tuple{Vararg{UnitRange{Int}}}
 
 # TODO: Types and check on R <: Real for initial, final, goal
 
-
 # ---------------------------------------------------------------------------- #
 # Named Trajectory
 # ---------------------------------------------------------------------------- #
@@ -81,10 +80,10 @@ function NamedTrajectory(
     final=NamedTuple(),
     goal=NamedTuple(),
     gdata::AbstractVector{R}=R[],
-    gcomps::NamedTuple{GN, <:ComponentType} where GN=NamedTuple(),
+    gcomponents::NamedTuple{GN, <:ComponentType} where GN=NamedTuple(),
 ) where R <: Real
     @assert :data ∉ keys(comps) "data is a reserved name"
-    @assert isdisjoint(keys(comps), keys(gcomps)) "components and global components should use unique names"
+    @assert isdisjoint(keys(comps), keys(gcomponents)) "components and global components should use unique names"
 
     @assert timestep isa Symbol && timestep ∈ keys(comps)
 
@@ -115,8 +114,8 @@ function NamedTrajectory(
 
     # global data 
     gdim = length(gdata)
-    gdims = NamedTuple([(k => length(v)) for (k, v) ∈ pairs(gcomps)])
-    gnames = Tuple(keys(gcomps))
+    gdims = NamedTuple([(k => length(v)) for (k, v) ∈ pairs(gcomponents)])
+    gnames = Tuple(keys(gcomponents))
 
     # check global data
     @assert gdim == sum(values(gdims), init=0) "invalid global data dims"
@@ -138,7 +137,7 @@ function NamedTrajectory(
         gdata,
         gdim,
         gdims,
-        gcomps,
+        gcomponents,
         gnames
     )
 end
@@ -244,10 +243,7 @@ function NamedTrajectory(
         final=traj.final,
         goal=traj.goal,
         gdata=gdata,
-        gdim=traj.gdim,
-        gdims=traj.gdims,
         gcomponents=traj.gcomponents,
-        gnames=traj.gnames
     )
 end
 

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -226,17 +226,17 @@ function NamedTrajectory(
     @assert all([v isa AbstractMatrix || v isa AbstractVector for v ∈ values(comps_data)])
     vals = [v isa AbstractVector ? reshape(v, 1, :) : v for v ∈ values(comps_data)]
     comps_data = NamedTuple([(k => v) for (k, v) ∈ zip(keys(comps_data), vals)])
-    return NamedTrajectory(comps_data, timestep; kwargs...)
+    return NamedTrajectory(comps_data; kwargs...)
 end
 
 """
     NamedTrajectory(data, traj)
 
-Construct a `NamedTrajectory` from a datavec and an existing `NamedTrajectory`.
+Construct a `NamedTrajectory` from an existing `NamedTrajectory`.
 """
 function NamedTrajectory(
-    datavec::AbstractVector{R},
     traj::NamedTrajectory;
+    datavec::AbstractVector{R}=traj.datavec,
     components::NamedTuple{N, <:ComponentType} where N=traj.components,
     T::Int=traj.T,
     timestep::Symbol=traj.timestep,
@@ -313,7 +313,7 @@ function get_bounds_from_dims(
                 throw(ArgumentError("Invalid bound $name: $(length(bound)) != $bdim"))
             end
             bounds_dict[name] = (-convert.(dtype, bound), convert.(dtype, bound))
-        elseif bound isa BoundType
+        elseif bound isa Tuple{<:AbstractVector{<:Real}, <:AbstractVector{<:Real}}
             if length(bound[1]) != bdim 
                 throw(ArgumentError("Invalid bound $name: $(length(bound[1])) != $bdim"))
             end
@@ -365,10 +365,10 @@ Check for proper formatting of trajectory components.
 """
 function inspect_dims_pairs(
     dims_pairs::Vector{Pair{Symbol, Int}},
-    bounds::NamedTuple{bname, <:Tuple{Vararg{BoundType}}} where bname,
-    initial::NamedTuple{iname, <:Tuple{Vararg{AbstractVector{R}}}} where iname,
-    final::NamedTuple{fname, <:Tuple{Vararg{AbstractVector{R}}}} where fname,
-    goal::NamedTuple{gname, <:Tuple{Vararg{AbstractVector{R}}}} where gname
+    bounds::NamedTuple{bname, <:BoundType{R}} where bname,
+    initial::NamedTuple{iname, <:DataType{R}} where iname,
+    final::NamedTuple{fname, <:DataType{R}} where fname,
+    goal::NamedTuple{gname, <:DataType{R}} where gname
 ) where R <: Real
     dims_tuple = NamedTuple(dims_pairs)
     for k in keys(bounds)

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -379,14 +379,15 @@ end
     @test traj.timestep == :Δt
     @test traj.dim == n
     @test traj.T == T
-    @test traj.names == [:x, :y, :Δt]
+    @test traj.names == (:x, :y, :Δt)
 
     traj = NamedTrajectory(data, (x = 1:3, y=4:4, z=5:5), timestep=:z)
     @test traj.data ≈ data
     @test traj.timestep == :z
     @test traj.dim == n
     @test traj.T == T
-    @test traj.names == [:x, :y, :z]
+    @test traj.names == (:x, :y, :z)
+
 end
 
 @testitem "Construct from component data" begin
@@ -423,12 +424,12 @@ end
     @test traj.T == T
     @test traj.dim == dim
     @test length(traj.gdata) == gdim
-    @test traj.names = [:x, :u, :Δt]
+    @test traj.names == (:x, :u, :Δt)
     @test traj.state_names == (:x,)
     @test traj.control_names == (:u, :Δt)
-    @test traj.gnames == [:α, :β]
+    @test traj.gnames == (:α, :β)
 
-    comps_res = NamedTuple([(k => traj.data[v, :]) for (k, v) in pairs(traj.components)]) 
+    comps_res = NamedTuple([(k => traj.data[v, :]) for (k, v) in pairs(traj.components)])
     @test comps_res == comps_data
 
     gres = NamedTuple([(k => traj.gdata[v]) for (k, v) in pairs(traj.gcomponents)])
@@ -436,11 +437,11 @@ end
 
     # ignore global
     # ---
-    traj = NamedTrajectory(comps_data)
+    traj = NamedTrajectory(comps_data, controls=control)
 
     @test traj.T == T
     @test traj.dim == dim
-    @test traj.names = [:x, :u, :Δt]
+    @test traj.names == (:x, :u, :Δt)
     @test traj.state_names == (:x,)
     @test traj.control_names == (:u, :Δt)
     @test isempty(traj.gnames)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,16 +1,5 @@
 using Random
 
-function get_fixed_time_traj(;
-    T::Int=5, 
-    Δt::Float64=0.1, 
-    x_dim::Int=3, 
-    a_dim::Int=2, 
-    kwargs...
-)
-    fixed_time_data = (x = rand(x_dim, T), u = rand(a_dim, T))
-    return NamedTrajectory(fixed_time_data; timestep=Δt, controls=:u, kwargs...)
-end
-
 function get_free_time_traj(;
     T::Int=5, 
     Δt::Symbol=:Δt, 
@@ -20,18 +9,6 @@ function get_free_time_traj(;
 )
     free_time_data = (x = rand(x_dim, T), u = rand(a_dim, T), Δt = rand(1, T))
     return NamedTrajectory(free_time_data; timestep=Δt, controls=:u, kwargs...)
-end
-
-function get_fixed_time_traj2(;
-    T::Int=5, 
-    Δt::Float64=0.1, 
-    x_dim::Int=3, 
-    y_dim=3, 
-    a_dim::Int=2,
-    kwargs...
-)
-    fixed_time_data = (x = rand(x_dim, T), y_dim = rand(y_dim, T), u = rand(a_dim, T))
-    return NamedTrajectory(fixed_time_data; timestep=Δt, controls=:u, kwargs...)
 end
 
 function named_trajectory_type_1(; free_time=false)


### PR DESCRIPTION
Changelog:
* NT as a parametric type avoids dynamic dispatch for components
* Uses ranges for components to guarantee non-allocating views when accessing with comps
* Refactors knot point as parametric, also
* Requires free time
* Sets global data to be relative to the global data, not the full trajectory datavec (no more index offset).

Some small changes to methods (could be breaking, e.g., there is no more in place `add_component!`, only `add_component`). The logic is now that data can be updated, but fields cannot. This is required when using parametric types.

Want feedback on whether `gdata` or `global_data`, `gnames` or `global_names` is the right naming style for the globals.