### PR TITLE
fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,6 @@ NamedTrajectories.jl is registered! Install in the REPL by entering pkg mode wit
 pkg> add NamedTrajectories
 ```
 
-or to install the latest master branch run
-
-```julia
-pkg> add NamedTrajectories#main
-```
-
 ### Features
 
 - Abstract away messy indexing and vectorization details required for interfacing with numerical solvers.
@@ -81,21 +75,22 @@ pkg> add NamedTrajectories#main
 
 Users can define `NamedTrajectory` types which have lots of useful functionality. For example, you can access the data by name or index.  In the case of an index, a `KnotPoint` is returned which contains the data for that timestep.
 
-```julia
+<!--```@example-->```julia
 using NamedTrajectories
 
 # define number of timesteps and timestep
 T = 10
-dt = 0.1
+timestep=:dt
 
 # build named tuple of components and data matrices
 components = (
-    x = rand(3, T),
-    u = rand(2, T),
+    x  = rand(3, T),
+    u  = rand(2, T),
+    dt = fill(0.1, T),
 )
 
 # build trajectory
-traj = NamedTrajectory(components; timestep=dt, controls=:u)
+traj = NamedTrajectory(components; timestep=timestep, controls=:u)
 
 # access data by name
 traj.x # returns 3x10 matrix of x data
@@ -106,9 +101,11 @@ z1 = traj[1] # returns KnotPoint with x and u data
 z1.x # returns 3 element vector of x data at timestep 1
 z1.u # returns 2 element vector of u data at timestep 1
 
+z1.dt # returns 10 element vector of timesteps
+
 traj.data # returns data as 5x10 matrix
 traj.names # returns names as tuple (:x, :u)
-```
+<!--```-->```
 
 ## Motivation
 


### PR DESCRIPTION
as mentioned in #90 - we should run the code in the readme in an example block

also removed the #main branch comment from docs and fixed example for changes made to make every trajectory free-time ready in v0.4.0