### PR TITLE
feat!: knot-count field N → K (trajectory.K)

### DIFF
--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -22,7 +22,7 @@ function Makie.convert_arguments(
     P::Makie.PointBased,
     traj::NamedTrajectory,
     comp::Int;
-    indices::AbstractVector{Int} = 1:traj.N,
+    indices::AbstractVector{Int} = 1:traj.K,
 )
     times = get_times(traj)[indices]
     positions = map(zip(indices, times)) do (i, t)
@@ -40,7 +40,7 @@ function Makie.convert_arguments(
     traj::NamedTrajectory,
     name::Symbol;
     transform::Union{Nothing,AbstractTransform} = nothing,
-    indices::AbstractVector{Int} = 1:traj.N,
+    indices::AbstractVector{Int} = 1:traj.K,
 )
     if !isnothing(transform)
         transform_data = try

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -15,21 +15,21 @@ function Base.show(io::IO, Z::NamedTrajectory)
 
     comp_str = join([format(n, Z.components[n]) for n in keys(Z.components)], ", ")
     if isempty(Z.global_data)
-        print(io, "N = ", Z.N, ", (", comp_str, ")")
+        print(io, "K = ", Z.K, ", (", comp_str, ")")
     else
         global_comp_str = join(
             [format(n, Z.global_components[n]) for n in keys(Z.global_components)],
             ", ",
         )
-        print(io, "N = ", Z.N, ", (", comp_str, "), (", global_comp_str, ")")
+        print(io, "K = ", Z.K, ", (", comp_str, "), (", global_comp_str, ")")
     end
 end
 
 """
-    length(Z::NamedTrajectory) = Z.dim * Z.N + Z.global_dim
+    length(Z::NamedTrajectory) = Z.dim * Z.K + Z.global_dim
 """
 function Base.length(Z::NamedTrajectory)
-    return Z.dim * Z.N + Z.global_dim
+    return Z.dim * Z.K + Z.global_dim
 end
 
 """
@@ -42,9 +42,9 @@ function Base.vec(Z::NamedTrajectory)
 end
 
 """
-    size(Z::NamedTrajectory) = (dim = Z.dim, N = Z.N, global_dim = Z.global_dim)
+    size(Z::NamedTrajectory) = (dim = Z.dim, K = Z.K, global_dim = Z.global_dim)
 """
-Base.size(Z::NamedTrajectory) = (dim = Z.dim, N = Z.N, global_dim = Z.global_dim)
+Base.size(Z::NamedTrajectory) = (dim = Z.dim, K = Z.K, global_dim = Z.global_dim)
 
 """
     copy(::NamedTrajectory)
@@ -54,7 +54,7 @@ Returns a shallow copy of the trajectory.
 function Base.copy(traj::NamedTrajectory)
     NamedTrajectory(
         traj.datavec,
-        traj.N,
+        traj.K,
         traj.timestep,
         traj.dim,
         traj.dims,
@@ -86,7 +86,7 @@ end
     - `k::Int`: The timestep of the KnotPoint.
 """
 function StructKnotPoint.KnotPoint(Z::NamedTrajectory, k::Int)
-    @assert 1 ≤ k ≤ Z.N
+    @assert 1 ≤ k ≤ Z.K
     timestep = Z[Z.timestep][k]
     return KnotPoint(
         k,
@@ -119,7 +119,7 @@ end
 
 Returns the final time index of the trajectory.
 """
-Base.lastindex(traj::NamedTrajectory) = traj.N
+Base.lastindex(traj::NamedTrajectory) = traj.K
 
 """
     getindex(traj, symb::Symbol)
@@ -135,7 +135,7 @@ Returns the component of the trajectory with name `symb` (as a view) or the prop
 """
 function Base.getproperty(traj::NamedTrajectory, symb::Symbol)
     if symb == :data
-        return reshape(view(traj.datavec, :), :, traj.N)
+        return reshape(view(traj.datavec, :), :, traj.K)
     elseif symb ∈ fieldnames(NamedTrajectory)
         return getfield(traj, symb)
     elseif symb in traj.names
@@ -217,14 +217,14 @@ Base.:*(traj::NamedTrajectory, α::Float64) = α * NamedTrajectory(traj)
 function Base.:+(traj1::NamedTrajectory, traj2::NamedTrajectory)
     @assert traj1.names == traj2.names
     @assert traj1.dim == traj2.dim
-    @assert traj1.N == traj2.N
+    @assert traj1.K == traj2.K
     return NamedTrajectory(traj1, datavec = traj1.datavec + traj2.datavec)
 end
 
 function Base.:-(traj1::NamedTrajectory, traj2::NamedTrajectory)
     @assert traj1.names == traj2.names
     @assert traj1.dim == traj2.dim
-    @assert traj1.N == traj2.N
+    @assert traj1.K == traj2.K
     return NamedTrajectory(traj1, datavec = traj1.datavec - traj2.datavec)
 end
 
@@ -342,7 +342,7 @@ end
     @test vec(traj) == vcat(traj.datavec, traj.global_data)
 end
 
-@testitem "size returns (dim, N, global_dim)" begin
+@testitem "size returns (dim, K, global_dim)" begin
     traj = NamedTrajectory(
         randn(5, 10),
         (x = 1:3, y = 4:4, z = 5:5);
@@ -352,14 +352,14 @@ end
     )
     sz = size(traj)
     @test sz.dim == 5
-    @test sz.N == 10
+    @test sz.K == 10
     @test sz.global_dim == 3
 end
 
 @testitem "show prints components and global components" begin
     traj_no_global = NamedTrajectory(randn(3, 4), (x = 1:2, z = 3:3); timestep = :z)
     str_no_global = sprint(show, traj_no_global)
-    @test occursin("N = 4", str_no_global)
+    @test occursin("K = 4", str_no_global)
     @test occursin("→ z", str_no_global)
     @test occursin("x", str_no_global)
     @test !occursin("),  (", str_no_global)
@@ -372,7 +372,7 @@ end
         global_components = (g = 1:2,),
     )
     str_global = sprint(show, traj_global)
-    @test occursin("N = 4", str_global)
+    @test occursin("K = 4", str_global)
     @test occursin("g = 1:2", str_global)
 end
 

--- a/src/methods_knot_point.jl
+++ b/src/methods_knot_point.jl
@@ -77,7 +77,7 @@ end
     x_new = rand(size(x_orig)...)
     u_new = rand(size(u_orig)...)
 
-    idx = rand(1:traj.N)
+    idx = rand(1:traj.K)
 
     traj[idx].x = deepcopy(x_new[:, idx])
     @test traj.x[:, idx] ==

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -119,7 +119,7 @@ function get_times(traj::NamedTrajectory)
     if traj.timestep isa Symbol
         return cumsum([0.0, vec(traj[traj.timestep])[1:(end-1)]...])
     else
-        return [0:(traj.N-1)...] * traj.timestep
+        return [0:(traj.K-1)...] * traj.timestep
     end
 end
 
@@ -132,7 +132,7 @@ function get_timesteps(traj::NamedTrajectory)
     if traj.timestep isa Symbol
         return vec(traj[traj.timestep])
     else
-        return fill(traj.timestep, traj.N)
+        return fill(traj.timestep, traj.K)
     end
 end
 
@@ -154,11 +154,11 @@ function extend_datavec(
     ext_data::AbstractMatrix{R},
 ) where {R<:Real}
     @assert size(data, 2) == size(ext_data, 2)
-    N = size(data, 2)
+    K = size(data, 2)
     dim = size(data, 1)
     ext_dim = size(ext_data, 1)
-    new_datavec = zeros((dim + ext_dim) * N)
-    for k = 1:N
+    new_datavec = zeros((dim + ext_dim) * K)
+    for k = 1:K
         # fill original data
         copyto!(new_datavec, (k - 1) * (dim + ext_dim) + 1, data[:, k], 1, dim)
         # fill new data
@@ -213,7 +213,7 @@ function add_components(
         )
     elseif type ∈ [:state, :control, :slack]
         @assert all([data isa AbstractMatrix for data in values(comps_data)])
-        @assert all([size(data, 2) == traj.N for (name, data) in pairs(comps_data)])
+        @assert all([size(data, 2) == traj.K for (name, data) in pairs(comps_data)])
         @assert all([name ∉ keys(traj.components) for (name, data) in pairs(comps_data)])
 
         # update components
@@ -268,8 +268,8 @@ function add_component(
     kwargs...,
 )
     if type != :global && data isa AbstractVector
-        @assert length(data) == traj.N "Data length must match trajectory N"
-        comp_data = (; name => reshape(data, 1, traj.N),)
+        @assert length(data) == traj.K "Data length must match trajectory K"
+        comp_data = (; name => reshape(data, 1, traj.K),)
     else
         comp_data = (; name => data,)
     end
@@ -342,7 +342,7 @@ Update a component of the trajectory.
 function update!(traj::NamedTrajectory, name::Symbol, data::AbstractMatrix{Float64})
     @assert name ∈ traj.names
     @assert size(data, 1) == traj.dims[name]
-    @assert size(data, 2) == traj.N
+    @assert size(data, 2) == traj.K
     traj.data[traj.components[name], :] = data
     return nothing
 end
@@ -361,8 +361,8 @@ function update!(traj::NamedTrajectory, datavec::AbstractVector{Float64}; type =
     elseif type == :global
         traj.global_data[:] = datavec
     elseif type == :both
-        traj.datavec[:] = datavec[1:(traj.dim*traj.N)]
-        traj.global_data[:] = datavec[(traj.dim*traj.N+1):(traj.dim*traj.N+traj.global_dim)]
+        traj.datavec[:] = datavec[1:(traj.dim*traj.K)]
+        traj.global_data[:] = datavec[(traj.dim*traj.K+1):(traj.dim*traj.K+traj.global_dim)]
     end
     return nothing
 end
@@ -755,7 +755,7 @@ traj_random = add_control_derivatives(
 # Notes
 - The original trajectory is not modified; a new trajectory is returned
 - When `random_init=false`, derivatives are computed using finite differences: du/dt ≈ Δu/Δt
-- When `random_init=true`, derivatives are sampled from N(0, drive_derivative_σ²)
+- When `random_init=true`, derivatives are sampled from K(0, drive_derivative_σ²)
 - The penultimate point of each derivative is adjusted to ensure smooth transitions (finite difference mode only)
 - New derivative components become part of the trajectory controls
 """
@@ -1078,19 +1078,19 @@ end
 
 @testitem "add component" begin
     using Random
-    N = 10
+    K = 10
     dim = 5
-    data = randn(dim, N)
+    data = randn(dim, K)
     traj = NamedTrajectory(data, (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
 
-    traj1 = add_component(traj, :b, randn(N))
+    traj1 = add_component(traj, :b, randn(K))
     @test traj1.data[1:dim, :] == data
 
-    traj2 = add_component(traj, :b, randn(2, N))
+    traj2 = add_component(traj, :b, randn(2, K))
     @test traj2.data[1:dim, :] == data
 
-    da = randn(2, N)
-    db = randn(3, N)
+    da = randn(2, K)
+    db = randn(3, K)
     traj3 = add_components(traj, (a = da, b = db))
     @test traj3.data[1:dim, :] == data
     @test traj3[:a] == da
@@ -1105,8 +1105,8 @@ end
 
 @testitem "get_globals" begin
     using Random
-    N = 10
-    data = randn(5, N)
+    K = 10
+    data = randn(5, K)
 
     # happy path: multiple globals with mixed dimensions
     traj = NamedTrajectory(
@@ -1159,8 +1159,8 @@ end
 end
 
 @testitem "remove component" begin
-    N = 10
-    data = randn(5, N)
+    K = 10
+    data = randn(5, K)
     traj = NamedTrajectory(data, (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
     traj1 = remove_component(traj, :y)
     for name in [:x, :z]
@@ -1177,8 +1177,8 @@ end
     @test traj2.timestep == :y
 
     # remove multiple
-    da = randn(2, N)
-    db = randn(3, N)
+    da = randn(2, K)
+    db = randn(3, K)
     traj3 = add_components(traj, (a = da, b = db))
     @test remove_components(traj3, [:a, :b]) == traj
 
@@ -1199,8 +1199,8 @@ end
 
 @testitem "update! data" begin
     using Random
-    N = 10
-    data = randn(5, N)
+    K = 10
+    data = randn(5, K)
     global_data = [1.0, 2.0]
     orig_data = copy(data)
     orig_global_data = copy(global_data)
@@ -1213,19 +1213,19 @@ end
     )
 
     # update data
-    update!(traj, :x, zeros(traj.dims[:x], N))
-    @test traj[:x] == zeros(traj.dims[:x], N)
+    update!(traj, :x, zeros(traj.dims[:x], K))
+    @test traj[:x] == zeros(traj.dims[:x], K)
     @test traj[:y] == orig_data[traj.components[:y], :]
     @test traj[:z] == orig_data[traj.components[:z], :]
 
     # update datavec
-    update!(traj, ones(traj.dim * traj.N))
-    @test traj.datavec == ones(traj.dim * traj.N)
+    update!(traj, ones(traj.dim * traj.K))
+    @test traj.datavec == ones(traj.dim * traj.K)
     @test traj.global_data == orig_global_data
 
     # update global data
     update!(traj, zeros(traj.global_dim), type = :global)
-    @test traj.datavec == ones(traj.dim * traj.N) # stays the same from before
+    @test traj.datavec == ones(traj.dim * traj.K) # stays the same from before
     @test traj.global_data == zeros(traj.global_dim) # changes
 
     # update both
@@ -1275,9 +1275,9 @@ end
 
 @testitem "merge" begin
     using Random
-    N = 10
-    traj1 = NamedTrajectory(randn(5, N), (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
-    traj2 = NamedTrajectory(randn(5, N), (a = 1:3, b = 4:4, c = 5:5), timestep = :c)
+    K = 10
+    traj1 = NamedTrajectory(randn(5, K), (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
+    traj2 = NamedTrajectory(randn(5, K), (a = 1:3, b = 4:4, c = 5:5), timestep = :c)
 
     traj3 = merge(traj1, traj2)
     @test traj3.timestep == traj2.timestep
@@ -1288,8 +1288,8 @@ end
     @test issetequal(traj3.names, vcat(traj1.names..., traj2.names...))
 
     # merge x, u, Δt
-    traj1 = rand(NamedTrajectory, N)
-    traj2 = rand(NamedTrajectory, N)
+    traj1 = rand(NamedTrajectory, K)
+    traj2 = rand(NamedTrajectory, K)
     trajs_merged =
         merge([traj1, traj2]; merge_names = (x = 1, u = 2, Δt = 1), timestep = :Δt)
     @test trajs_merged.timestep == :Δt
@@ -1310,7 +1310,7 @@ end
     )
 
     # merge vector
-    trajs = [rand(NamedTrajectory, N) for _ = 1:5]
+    trajs = [rand(NamedTrajectory, K) for _ = 1:5]
     trajs_merged = merge(trajs; merge_names = (x = 1, u = 2, Δt = 1), timestep = :Δt)
     @test trajs_merged isa NamedTrajectory
 
@@ -1327,8 +1327,8 @@ end
 end
 
 @testitem "suffix tests" begin
-    N = 10
-    data = randn(5, N)
+    K = 10
+    data = randn(5, K)
     traj = NamedTrajectory(
         data,
         (x = 1:3, y = 4:4, z = 5:5),
@@ -1351,7 +1351,7 @@ end
     @test traj_suffixed.bounds == add_suffix(traj.bounds, suffix)
 
     # test removing suffix
-    traj2 = NamedTrajectory(randn(5, N), (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
+    traj2 = NamedTrajectory(randn(5, K), (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
     merge_traj = merge(traj_suffixed, traj2)
     # need to choose the right timestep to keep
     traj_unsuffixed =

--- a/src/random_trajectories.jl
+++ b/src/random_trajectories.jl
@@ -7,7 +7,7 @@ using ..StructNamedTrajectory
 """
     rand(
         ::Type{NamedTrajectory},
-        N::Int;
+        K::Int;
         timestep_value::Float64=1.0,
         timestep_name::Symbol=:Δt,
         timestep::Union{Float64,Symbol}=free_time ? timestep_name : timestep_value,
@@ -15,11 +15,11 @@ using ..StructNamedTrajectory
         control_dim::Int=2
     )
 
-Create a random `NamedTrajectory` with `N` knot points, a state variable `x` of dimension  `state_dim`, and a control variable `u` of dimension `control_dim`. The time step is a symbol `timestep_name` and the time step value is `timestep_value`. 
+Create a random `NamedTrajectory` with `K` knot points, a state variable `x` of dimension  `state_dim`, and a control variable `u` of dimension `control_dim`. The time step is a symbol `timestep_name` and the time step value is `timestep_value`. 
 """
 function Base.rand(
     ::Type{NamedTrajectory},
-    N::Int;
+    K::Int;
     timestep_value::Float64 = 1.0,
     timestep::Symbol = :Δt,
     state::Symbol = :x,
@@ -28,9 +28,9 @@ function Base.rand(
     control_dim::Int = 2,
 )
     comps_data = (;
-        state => randn(state_dim, N),
-        control => randn(control_dim, N),
-        timestep => fill(timestep_value, 1, N),
+        state => randn(state_dim, K),
+        control => randn(control_dim, K),
+        timestep => fill(timestep_value, 1, K),
     )
 
     return NamedTrajectory(comps_data; timestep = timestep, controls = (control, timestep))

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -63,7 +63,7 @@ mutable struct NamedTrajectory{
     GN<:NameType,
 }
     datavec::AbstractVector{R}
-    N::Int
+    K::Int
     timestep::Symbol
     dim::Int
     dims::NamedTuple{DNames,DTypes}
@@ -83,14 +83,14 @@ mutable struct NamedTrajectory{
 end
 
 """
-    NamedTrajectory(datavec, components, N)
+    NamedTrajectory(datavec, components, K)
 
 Construct a named trajectory from a data vector, components, and knot points.
 """
 function NamedTrajectory(
     datavec::AbstractVector{R},
     comps::NamedTuple{N,<:ComponentType} where {N},
-    N::Int;
+    K::Int;
     timestep::Symbol = :Δt,
     controls::Union{Symbol,NameType} = timestep,
     bounds = NamedTuple(),
@@ -120,7 +120,7 @@ function NamedTrajectory(
     dims_pairs = [(k => length(v)) for (k, v) ∈ pairs(comps)]
     dims = NamedTuple(dims_pairs)
     dim = sum(values(dims), init = 0)
-    @assert dim * N == length(datavec) "Data vector length does not match components"
+    @assert dim * K == length(datavec) "Data vector length does not match components"
 
     # process and save bounds
     bounds = get_bounds_from_dims(bounds, dims, dtype = R)
@@ -138,7 +138,7 @@ function NamedTrajectory(
 
     return NamedTrajectory(
         datavec,
-        N,
+        K,
         timestep,
         dim,
         dims,
@@ -172,7 +172,7 @@ function NamedTrajectory(
     # element types via the tuple — a list comprehension would widen to
     # `Vector{<:AbstractMatrix{<:Real}}` and trip JET's type inference.
     data = vcat(values(comps_data)...)
-    dim, N = size(data)
+    dim, K = size(data)
 
     # save components of data matrix
     dims_pairs = [(k => size(v, 1)) for (k, v) ∈ pairs(comps_data)]
@@ -199,14 +199,14 @@ function NamedTrajectory(
         return NamedTrajectory(
             vec(convert.(R, data)),
             comps,
-            N;
+            K;
             global_data = convert.(R, global_data),
             global_components = gcomps,
             kwargs...,
         )
     else
         # user can specify global data using `global_data`, `global_components`
-        return NamedTrajectory(vec(data), comps, N; kwargs...)
+        return NamedTrajectory(vec(data), comps, K; kwargs...)
     end
 end
 
@@ -250,7 +250,7 @@ function NamedTrajectory(
     traj::NamedTrajectory;
     datavec::AbstractVector{R} = traj.datavec,
     components::NamedTuple{N,<:ComponentType} where {N} = traj.components,
-    N::Int = traj.N,
+    K::Int = traj.K,
     timestep::Symbol = traj.timestep,
     controls::Union{Symbol,NameType} = traj.control_names,
     bounds = traj.bounds,
@@ -260,7 +260,7 @@ function NamedTrajectory(
     global_data::AbstractVector{R} = traj.global_data,
     global_components::NamedTuple{GN,<:ComponentType} where {GN} = traj.global_components,
 ) where {R<:Real}
-    @assert length(datavec) == sum(length.(values(components)), init = 0) * N "Data vector length does not match components * N"
+    @assert length(datavec) == sum(length.(values(components)), init = 0) * K "Data vector length does not match components * K"
     @assert length(global_data) == sum(length.(values(global_components)), init = 0) "Global data length does not match global components"
 
     # Only collect lazy arrays and other non-strided AbstractVectors
@@ -274,7 +274,7 @@ function NamedTrajectory(
     return NamedTrajectory(
         datavec_concrete,
         components,
-        N;
+        K;
         timestep = timestep,
         controls = controls,
         bounds = bounds,
@@ -296,9 +296,9 @@ function NamedTrajectory(
     comps::NamedTuple{N,<:ComponentType} where {N};
     kwargs...,
 ) where {R<:Real}
-    N = size(data, 2)
+    K = size(data, 2)
     datavec = vec(data)
-    return NamedTrajectory(datavec, comps, N; kwargs...)
+    return NamedTrajectory(datavec, comps, K; kwargs...)
 end
 
 # ----------------------------------------------------------------------------- #
@@ -407,31 +407,31 @@ end
 
 @testitem "Construct from data matrix and comps" begin
     n = 5
-    N = 10
-    data = randn(n, N)
+    K = 10
+    data = randn(n, K)
     traj = NamedTrajectory(data, (x = 1:3, y = 4:4, Δt = 5:5))
     @test traj.data ≈ data
     @test traj.timestep == :Δt
     @test traj.dim == n
-    @test traj.N == N
+    @test traj.K == K
     @test traj.names == (:x, :y, :Δt)
 
     traj = NamedTrajectory(data, (x = 1:3, y = 4:4, z = 5:5), timestep = :z)
     @test traj.data ≈ data
     @test traj.timestep == :z
     @test traj.dim == n
-    @test traj.N == N
+    @test traj.K == K
     @test traj.names == (:x, :y, :z)
 
 end
 
 @testitem "Construct from component data" begin
     # define number of timesteps and timestep
-    N = 10
+    K = 10
     dt = 0.1
 
     dim = 6
-    comps_data = (x = rand(3, N), u = rand(2, N), Δt = fill(dt, 1, N))
+    comps_data = (x = rand(3, K), u = rand(2, K), Δt = fill(dt, 1, K))
 
     timestep = :Δt
     control = :u
@@ -444,7 +444,7 @@ end
     # ---
     traj = NamedTrajectory(comps_data, gcomps_data; timestep = timestep, controls = control)
 
-    @test traj.N == N
+    @test traj.K == K
     @test traj.dim == dim
     @test length(traj.global_data) == global_dim
     @test traj.names == (:x, :u, :Δt)
@@ -463,7 +463,7 @@ end
     # ---
     traj = NamedTrajectory(comps_data, controls = control)
 
-    @test traj.N == N
+    @test traj.K == K
     @test traj.dim == dim
     @test traj.names == (:x, :u, :Δt)
     @test traj.state_names == (:x,)
@@ -502,12 +502,12 @@ end
 
 @testitem "Test AbstractVector datavec handling" begin
     # Create a base trajectory
-    N = 10
+    K = 10
     x_dim = 2
     u_dim = 1
 
     base_traj = NamedTrajectory(
-        (x = randn(x_dim, N), u = randn(u_dim, N), Δt = fill(0.1, N));
+        (x = randn(x_dim, K), u = randn(u_dim, K), Δt = fill(0.1, K));
         controls = :u,
         timestep = :Δt,
     )


### PR DESCRIPTION
Closes #144.

The NamedTrajectories side of the Piccolo 2.0 knot-count rename (umbrella Piccolissimo #423; the ket-count prep that frees the letter K across the stack is Piccolissimo #436/#437).

**Breaking (0.10.0, lockstep with Piccolo 2.0.0):**
- field `traj.N` → `traj.K`
- positional constructor arg + rebuild kwarg `N = …` → `K = …`
- `size(traj)` NamedTuple key `N` → `K`
- `show` prints `K = …`

**Untouched by design:** NamedTuple name-set type parameters (`N` in `NamedTuple{N,…}` — never knot semantics), `global_dim`, `dim`.

**Verification:** full suite green locally — 367/367 in 1m02s; zero `.N`/`N::Int` gated patterns remain in src+ext (only NamedTuple type params).