### PR TITLE
chore: knot points for N in prose, timestep reserved for Δt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ pkg> add NamedTrajectories
 
 ## Basic Usage
 
-Users can define `NamedTrajectory` types which have lots of useful functionality. For example, you can access the data by name or index.  In the case of an index, a `KnotPoint` is returned which contains the data for that timestep.
+Users can define `NamedTrajectory` types which have lots of useful functionality. For example, you can access the data by name or index.  In the case of an index, a `KnotPoint` is returned which contains the data for that knot point.
 
 ```julia example
 using NamedTrajectories
 
-# define number of timesteps and timestep
+# define number of knot points and timestep
 N = 10
 timestep=:dt
 
@@ -98,8 +98,8 @@ traj.u # returns 2x10 matrix of u data
 
 z1 = traj[1] # returns KnotPoint with x and u data
 
-z1.x # returns 3 element vector of x data at timestep 1
-z1.u # returns 2 element vector of u data at timestep 1
+z1.x # returns 3 element vector of x data at knot point 1
+z1.u # returns 2 element vector of u data at knot point 1
 
 z1.dt # returns 10 element vector of timesteps
 
@@ -160,7 +160,7 @@ The trajectory optimization problem can then be succinctly written as
 \end{align*}
 ```
 
-The `NamedTrajectories` package provides a `NamedTrajectory` type which abstracts away the messy indexing and vectorization details required for interfacing with numerical solvers.  It also provides a variety of helpful methods for common tasks.  For example, you can access the data by name or index.  In the case of an index, a `KnotPoint` is returned which contains the data for that timestep.
+The `NamedTrajectories` package provides a `NamedTrajectory` type which abstracts away the messy indexing and vectorization details required for interfacing with numerical solvers.  It also provides a variety of helpful methods for common tasks.  For example, you can access the data by name or index.  In the case of an index, a `KnotPoint` is returned which contains the data for that knot point.
 
 
 ### Building Documentation

--- a/docs/literate/man/constructors.jl
+++ b/docs/literate/man/constructors.jl
@@ -4,7 +4,7 @@
 
 using NamedTrajectories
 
-## define number of timesteps and timestep
+## define number of knot points and timestep
 N = 10
 dt = 0.1
 

--- a/docs/literate/man/modifying.jl
+++ b/docs/literate/man/modifying.jl
@@ -14,7 +14,7 @@ Other times, you may want to add or remove components from the trajectory.
 
 using NamedTrajectories
 
-# Create a random trajectory with 5 time steps, a state variable `x` of dimension 3, and a control variable `u` of dimension 2
+# Create a random trajectory with 5 knot points, a state variable `x` of dimension 3, and a control variable `u` of dimension 2
 traj = rand(NamedTrajectory, 5)
 traj.names
 

--- a/docs/literate/man/params_in_struct.jl
+++ b/docs/literate/man/params_in_struct.jl
@@ -3,7 +3,7 @@
 
 using NamedTrajectories
 
-# First we need to define number of timesteps and timestep
+# First we need to define number of knot points and timestep
 N = 10
 dt = 0.1
 

--- a/docs/literate/quickstart.jl
+++ b/docs/literate/quickstart.jl
@@ -27,7 +27,7 @@ where $x_k$ is the state and $u_k$ is the control at a time indexed by $k$. Toge
 Here we will create a `NamedTrajectory` with a variable timestep.
 =#
 
-## define the number of timesteps
+## define the number of knot points
 N = 10
 Δt = 0.1
 
@@ -51,7 +51,7 @@ traj.names
 In many settings we will want to specify the problem data of our `NamedTrajectory` -- e.g. bounds, initial values, final values, and goal values. 
 =#
 
-## define the number of timesteps
+## define the number of knot points
 N = 10
 
 ## define the knot point data as a NamedTuple of matrices

--- a/ext/InterpolationsExt.jl
+++ b/ext/InterpolationsExt.jl
@@ -92,22 +92,22 @@ end
         kwargs...
     )
 
-Interpolate a `NamedTrajectory` to a new number of time steps.
+Interpolate a `NamedTrajectory` to a new number of knot points.
 
 # Arguments
 - `traj::NamedTrajectory`: The trajectory to interpolate.
-- `T::Int`: The number of time steps in the interpolated trajectory.
+- `T::Int`: The number of knot points in the interpolated trajectory.
 
 # Keyword Arguments
 - `kwargs...`: Additional keyword arguments passed to the main `trajectory_interpolation` method.
 
 # Returns
-- `NamedTrajectory`: A new trajectory with `T` time steps, evenly spaced between the original 
+- `NamedTrajectory`: A new trajectory with `T` knot points, evenly spaced between the original 
   start and end times.
 
 # Examples
 ```julia
-# Interpolate to 100 time steps
+# Interpolate to 100 knot points
 new_traj = trajectory_interpolation(traj, 100)
 
 # With custom interpolation methods

--- a/ext/PlottingExt.jl
+++ b/ext/PlottingExt.jl
@@ -116,7 +116,7 @@ function Makie.plot!(p::TrajectoryPlot)
         if isnothing(trans)
             K = init_data isa AbstractVector ? 1 : size(init_data, 1)
         elseif trans isa Vector
-            # Vector transform implies per-timestep transformation (zip with columns)
+            # Vector transform implies per-knot-point transformation (zip with columns)
             # Determine K from the output of the transform on the first column
             val = trans[1](init_data[:, 1])
             K = length(val)

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -83,7 +83,7 @@ end
 
     # Arguments
     - `Z::NamedTrajectory`: The trajectory from which the KnotPoint is taken.
-    - `k::Int`: The timestep of the KnotPoint.
+    - `k::Int`: The index of the knot point.
 """
 function StructKnotPoint.KnotPoint(Z::NamedTrajectory, k::Int)
     @assert 1 ≤ k ≤ Z.N
@@ -101,7 +101,7 @@ end
 """
     getindex(traj, k::Int)::KnotPoint
 
-Returns the knot point at time `k`.
+Returns the knot point at index `k`.
 """
 Base.getindex(traj::NamedTrajectory, k::Int) = KnotPoint(traj, k)
 

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -426,7 +426,7 @@ end
 end
 
 @testitem "Construct from component data" begin
-    # define number of timesteps and timestep
+    # define number of knot points and timestep
     N = 10
     dt = 0.1
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,7 +89,7 @@ end
     @test_throws AssertionError load_traj("missing.txt")
 end
 
-@testitem "derivative: vector and Float64 timesteps agree on uniform grid" begin
+@testitem "derivative: vector and Float64 timestep values agree on uniform grid" begin
     X = [1.0 2.0 4.0 7.0 11.0; 0.0 1.0 4.0 9.0 16.0]
     Δt_vec = fill(0.5, size(X, 2))
     dX_vec = derivative(X, Δt_vec)
@@ -109,7 +109,7 @@ end
     @test dX_mat ≈ dX_vec
 end
 
-@testitem "integral: vector and Float64 timesteps agree on uniform grid" begin
+@testitem "integral: vector and Float64 timestep values agree on uniform grid" begin
     X = [1.0 2.0 3.0 4.0 5.0; 0.0 1.0 2.0 3.0 4.0]
     Δt_vec = fill(1.0, size(X, 2))
     ∫X = integral(X, Δt_vec)


### PR DESCRIPTION
Closes #146

## What

Prose-only notation pass aligning the package's language with the convention canonicalized in Piccolo's concepts guide (**Piccolo `chore/notation-pass`**; cross-repo tracking: harmoniqs/Piccolissimo.jl#423):

- **N** = number of **knot points** (nodes, per the direct multiple-shooting literature). Prose says "knot points" on first mention, "knots" after.
- **"timestep"** exclusively = the per-knot $\Delta t_k$ (the `timestep::Symbol` component — its name and docstrings are correct and unchanged). Never the count.

The code already speaks knot (`traj.N`, `KnotPoint`); the prose lagged behind. This PR catches the prose up.

## Scope — ZERO identifier/API changes

20 insertions / 20 deletions, all in docstrings, comments, README prose, Literate docs, and two `@testitem` label strings (pure labels; `@run_package_tests` discovers by file, nothing references titles). `docs/build` untouched.

## Classification of every `timestep(s)` hit (163 total incl. code)

- **Kept — Δt-sense, already correct** (`timestep::Symbol` field/kwarg docs, `get_timesteps` docstring, "variable timestep" free-time prose, "Missing timestep in components" assert, `z1.dt` → "vector of timesteps", merge kwarg docs, `random_trajectories.jl` docstring which already said "`N` knot points").
- **Fixed — count-sense (19 lines in 10 files)**: "number of timesteps" → "number of knot points" (README, `struct_named_trajectory.jl` test comment, quickstart ×2, constructors, params_in_struct); "5/100/`T` time steps" → "… knot points" (modifying.jl, InterpolationsExt docstring ×4); "data for that timestep" / "at timestep 1" → "… knot point" (README ×4); `KnotPoint(Z, k)` doc "the timestep of the KnotPoint" → "the index of the knot point" (base_named_trajectory.jl); "per-timestep transformation" → "per-knot-point" (PlottingExt comment); "at time `k`" → "at index `k`".
- **Reworded to satisfy the gate regex** (2): `utils.jl` testitem titles "vector and Float64 timesteps" → "vector and Float64 timestep values" — Δt-sense either way; "Float64" merely trips `[0-9]+ timesteps`.

## Verification

- Gate: `grep -rniE 'number of timesteps|[0-9]+ timesteps' src/ README.md docs/` (excl. build) → **0 hits**.
- Parse-check (`Meta.parseall`) of all 9 changed `.jl` files → OK.
- `Pkg.test()` → **367/367 pass**, ~1 min.