### PR TITLE
Derived timestep rows via an optional warp (GlobalScale v1): Δt present but never decision data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to NamedTrajectories.jl are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the package
 follows Julia 0.x SemVer.
 
+## [Unreleased]
+
+### Added
+
+- **Derived timestep rows via an optional time warp (#160).** `NamedTrajectory`
+  gains a `warp` keyword (`AbstractTimeWarp`, new public API in `time_warp.jl`:
+  `GlobalScale`, `PiecewiseLinearWarp`, `deltats`, `deltats_row`, `knot_times`,
+  `duration`, `is_monotone`, `warp_params`, `n_params`, `with_params`,
+  `ddeltats_dparams`). Under a warp the timestep rows are derived —
+  `Δtₖ = T·wₖ` with exact rational lattice weights — present as components
+  (`get_times`, plotting, rollouts unchanged) but excluded from the packed
+  decision vector: `vec(traj)` / `length(traj)` drop them and append the trailing
+  warp parameters, and the new `unpack!(traj, z)` writes non-derived components
+  only, rebuilds the warp via `with_params`, then `sync_timesteps!` re-derives
+  the rows (single writer). Exclusion is by component role (`get_derived_names`),
+  never by name. `warp = nothing` (the default) is behavior-identical to the
+  historical accounting; merging warped trajectories throws.
+
 ## [0.9.3] — 2026-08-20
 
 ### Fixed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -115,11 +115,27 @@ get_timesteps(traj)  # Vector of Δt values
 get_duration(traj)   # Total duration T
 ```
 
+## Derived Timesteps (time warp)
+
+With `NamedTrajectory(comps; warp = GlobalScale(T))` the timestep rows are
+**derived** — `Δtₖ = T·wₖ` on the normalized lattice — via the new `time_warp.jl`:
+
+- The `:Δt` rows stay PRESENT as components (`get_times`, plotting, rollouts keep
+  working) but are EXCLUDED from the packed decision vector.
+- `vec(traj)` = per-knot non-derived rows, then globals, then the trailing warp
+  params (`GlobalScale`: the scalar `T`). `length(traj)` matches.
+- `unpack!(traj, z)` is the packed write path: writes non-derived components only,
+  rebuilds the warp via `with_params`, then `sync_timesteps!` re-derives the rows
+  (the single writer). `update!` with a packed vector throws under a warp.
+- Exclusion is by ROLE (`get_derived_names`), not by name.
+- `warp = nothing` (default) is behavior-identical to the historical accounting.
+
 ## Module Organization
 
 ```
 NamedTrajectories.jl/src/
 ├── NamedTrajectories.jl        # Main module (reexports all)
+├── time_warp.jl                # AbstractTimeWarp, GlobalScale, PiecewiseLinearWarp
 ├── struct_named_trajectory.jl  # NamedTrajectory type definition
 ├── struct_knot_point.jl        # KnotPoint type definition
 ├── base_named_trajectory.jl    # Base methods (indexing, copy, show)
@@ -144,6 +160,7 @@ Run: `julia --project -e 'using Pkg; Pkg.test()'`
 ## Gotchas
 
 - **timestep is always a control** - Even if not specified, `timestep` symbol is added to `control_names`
+- **derived timesteps under a warp** - The timestep rows are rewritten from `(warp, N)` by `sync_timesteps!`; never write them by hand, never pack them into `vec(traj)`
 - **bounds expand scalars** - `bounds=(u = 1.0,)` becomes `bounds=(u = ([-1.0, -1.0], [1.0, 1.0]),)` for 2D u
 - **views not copies** - `traj.x` returns a view; modifications affect `datavec`
 - **global_data is separate** - Not part of `datavec`, concatenated lazily in `vec(traj)`

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.9.3"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
@@ -24,6 +25,7 @@ PlottingExt = ["LaTeXStrings", "Makie"]
 Aqua = "0.8"
 CairoMakie = "0.12, 0.13, 0.14, 0.15"
 DataInterpolations = "8.1"
+ForwardDiff = "0.10, 1"
 JET = "0.9, 0.10, 0.11"
 JLD2 = "0.6"
 LaTeXStrings = "1"

--- a/src/NamedTrajectories.jl
+++ b/src/NamedTrajectories.jl
@@ -4,6 +4,9 @@ using Reexport
 
 @reexport using OrderedCollections: OrderedDict
 
+include("time_warp.jl")
+@reexport using .TimeWarp
+
 include("struct_named_trajectory.jl")
 @reexport using .StructNamedTrajectory
 

--- a/src/base_named_trajectory.jl
+++ b/src/base_named_trajectory.jl
@@ -1,15 +1,26 @@
 module BaseNamedTrajectory
 
+export unpack!
+export sync_timesteps!
+export get_derived_names
+
 using TestItems
 using LazyArrays
 
 using ..StructNamedTrajectory
 using ..StructKnotPoint
+using ..TimeWarp: AbstractTimeWarp, n_params, warp_params, with_params, deltats_row
 
 
 function Base.show(io::IO, Z::NamedTrajectory)
     @inline function format(name, inds)
-        str = name == Z.timestep ? "→ " * String(name) : String(name)
+        str = if name == Z.timestep && Z.warp !== nothing
+            "⇒ " * String(name)  # derived from the warp — never decision data
+        elseif name == Z.timestep
+            "→ " * String(name)
+        else
+            String(name)
+        end
         return "$(str) = $(inds)"
     end
 
@@ -26,19 +37,48 @@ function Base.show(io::IO, Z::NamedTrajectory)
 end
 
 """
-    length(Z::NamedTrajectory) = Z.dim * Z.N + Z.global_dim
+    length(Z::NamedTrajectory)
+
+Length of the packed decision vector: all non-derived components per knot, the
+global data, and the warp parameters. Without a warp this is the historical
+accounting `Z.dim * Z.N + Z.global_dim`; with a warp the derived timestep rows
+are excluded and `n_params(Z.warp)` is appended. Always `== length(vec(Z))`.
 """
 function Base.length(Z::NamedTrajectory)
-    return Z.dim * Z.N + Z.global_dim
+    warp = getfield(Z, :warp)
+    if warp === nothing
+        return Z.dim * Z.N + Z.global_dim
+    end
+    return (Z.dim - Z.dims[Z.timestep]) * Z.N + Z.global_dim + n_params(warp)
 end
 
 """
-    vec(Z::NamedTrajectory) = vcat(Z.datavec, Z.global_data)
+    vec(Z::NamedTrajectory)
 
+The packed decision vector. Without a warp this is the historical lazy
+concatenation `[Z.datavec; Z.global_data]`. With a warp, the derived timestep
+rows are **excluded**: per knot, the non-derived component rows in component
+order, then `Z.global_data`, then the trailing warp parameters
+(`warp_params(Z.warp)` — for [`GlobalScale`](@ref), the scalar duration `T`).
 """
 function Base.vec(Z::NamedTrajectory)
     # Allocation-free concatenation with LazyArrays
-    return ApplyArray(vcat, Z.datavec, Z.global_data)
+    warp = getfield(Z, :warp)
+    if warp === nothing
+        return ApplyArray(vcat, Z.datavec, Z.global_data)
+    end
+    # packed layout: drop the derived timestep row per knot; globals; warp params
+    zdim = Z.dim - Z.dims[Z.timestep]
+    dt_idx = first(Z.components[Z.timestep])
+    out = Vector{eltype(Z.datavec)}(undef, length(Z))
+    for k = 1:Z.N
+        block = view(Z.data, :, k)
+        copyto!(out, (k-1)*zdim + 1, block, 1, dt_idx - 1)
+        copyto!(out, (k-1)*zdim + dt_idx, block, dt_idx + 1, Z.dim - dt_idx)
+    end
+    copyto!(out, zdim*Z.N + 1, Z.global_data, 1, Z.global_dim)
+    copyto!(out, zdim*Z.N + Z.global_dim + 1, warp_params(warp), 1, n_params(warp))
+    return out
 end
 
 """
@@ -71,7 +111,95 @@ function Base.copy(traj::NamedTrajectory)
         traj.global_dims,
         traj.global_components,
         traj.global_names,
+        traj.warp,
     )
+end
+
+# -------------------------------------------------------------- #
+# Derived timesteps — the packed write path
+# -------------------------------------------------------------- #
+
+"""
+    get_derived_names(traj::NamedTrajectory)::Tuple{Vararg{Symbol}}
+
+Names of the DERIVED components — those present as rows but excluded from the
+packed decision vector. This is decided by the component's ROLE (the timestep of
+a warped trajectory), never by its name: a component named `:Δt` that is not the
+timestep is not derived, and the timestep is derived under a warp whatever its name.
+Returns `()` without a warp.
+"""
+function get_derived_names(traj::NamedTrajectory)
+    warp = getfield(traj, :warp)
+    return warp === nothing ? () : (traj.timestep,)
+end
+
+"""
+    sync_timesteps!(traj::NamedTrajectory)
+
+Rewrite the derived timestep rows from `(warp, N)` via [`deltats_row`](@ref). This is
+the ONLY writer of the derived rows — everything else goes through construction or
+[`unpack!`](@ref). No-op (returns `traj`) without a warp.
+"""
+function sync_timesteps!(traj::NamedTrajectory)
+    warp = getfield(traj, :warp)
+    warp === nothing && return traj
+    data = traj.data
+    data[traj.components[traj.timestep], :] .= reshape(deltats_row(warp, traj.N), 1, :)
+    return traj
+end
+
+"""
+    unpack!(traj::NamedTrajectory, z::AbstractVector{<:Real})
+
+Write the packed decision vector `z` — the layout of `vec(traj)` — into `traj`:
+
+  - the non-derived components only: under a warp the derived timestep rows are
+    NEVER written from `z`;
+  - the trailing warp-parameter block rebuilds `traj.warp` via [`with_params`](@ref)
+    (when the warp carries parameters);
+  - then [`sync_timesteps!`](@ref) re-derives the timestep rows.
+
+Throws `DimensionMismatch` when `length(z) != length(traj)`. Returns `traj`.
+"""
+function unpack!(traj::NamedTrajectory, z::AbstractVector{<:Real})
+    length(z) == length(traj) || throw(
+        DimensionMismatch(
+            "length(z) = $(length(z)) does not match the packed length $(length(traj))",
+        ),
+    )
+    warp = getfield(traj, :warp)
+    if warp === nothing
+        # nothing is derived: z is [datavec; global_data]
+        copyto!(traj.datavec, view(z, 1:(traj.dim*traj.N)))
+        copyto!(traj.global_data, view(z, (traj.dim*traj.N+1):length(z)))
+    else
+        _unpack_derived!(traj, warp, z)
+    end
+    sync_timesteps!(traj)
+    return traj
+end
+
+function _unpack_derived!(
+    traj::NamedTrajectory,
+    warp::AbstractTimeWarp,
+    z::AbstractVector{<:Real},
+)
+    zdim = traj.dim - traj.dims[traj.timestep]
+    dt_idx = first(traj.components[traj.timestep])
+    data = traj.data
+    for k = 1:traj.N
+        dst = view(data, :, k)
+        src0 = (k - 1) * zdim
+        copyto!(dst, 1, z, src0 + 1, dt_idx - 1)
+        copyto!(dst, dt_idx + 1, z, src0 + dt_idx, traj.dim - dt_idx)
+    end
+    # trailing warp parameters rebuild the warp
+    n = n_params(warp)
+    if n > 0
+        z0 = zdim * traj.N + traj.global_dim
+        traj.warp = with_params(warp, Vector{Float64}(view(z, (z0+1):(z0+n))))
+    end
+    return traj
 end
 
 # -------------------------------------------------------------- #
@@ -383,6 +511,145 @@ end
     @test length(knots) == 3
     @test knots[1].x == traj[2].x
     @test knots[end].x == traj[4].x
+end
+
+@testitem "packed vec and length exclude the derived timestep rows" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = w,
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+
+    z = vec(traj)
+
+    # dimension accounting: non-derived components per knot, globals, warp params
+    @test length(traj) == length(z) == (traj.dim - 1) * N + 2 + n_params(w)
+
+    # layout: per-knot non-derived rows in component order, then globals, then params
+    expected = Vector{Float64}(undef, 5 * N + 2 + 1)
+    for k = 1:N
+        expected[((k-1)*5+1):((k-1)*5+3)] = traj.x[:, k]
+        expected[((k-1)*5+4):((k-1)*5+5)] = traj.u[:, k]
+    end
+    expected[(5*N+1):(5*N+2)] = [1.0, 2.0]
+    expected[end] = 5.0
+    @test z == expected
+
+    # no-warp invariant: length(traj) == length(vec(traj)) still holds
+    plain = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+    @test length(plain) == length(vec(plain)) == plain.dim * N + 2
+end
+
+@testitem "unpack! round-trips the packed vector and syncs the warp" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = w,
+    )
+
+    z = vec(traj)
+    before = collect(traj.datavec)
+
+    # identity round trip: unpacking the packed vector changes nothing
+    @test unpack!(traj, z) === traj
+    @test traj.datavec == before
+    @test traj.Δt == reshape(deltats_row(w, N), 1, N)
+
+    # perturbed components and a perturbed T: unpack! writes the components,
+    # rebuilds the warp from the trailing params, and re-derives the Δt rows
+    z2 = copy(z)
+    z2[1] += 0.5
+    z2[4] -= 1.0
+    z2[end] = 7.5
+    unpack!(traj, z2)
+    @test traj.x[1, 1] == z2[1]
+    @test traj.u[1, 1] == z2[4]
+    @test traj.warp == GlobalScale(7.5)
+    @test traj.Δt == reshape(deltats_row(GlobalScale(7.5), N), 1, N)
+    @test vec(traj) == z2
+end
+
+@testitem "unpack! rejects a wrong-length packed vector" begin
+    using NamedTrajectories
+
+    traj = NamedTrajectory(
+        (x = randn(3, 5), u = randn(2, 5), Δt = fill(0.1, 1, 5));
+        controls = :u,
+        warp = GlobalScale(5.0),
+    )
+    @test_throws DimensionMismatch unpack!(traj, vec(traj)[1:(end-1)])
+    @test_throws DimensionMismatch unpack!(traj, vcat(vec(traj), 1.0))
+end
+
+@testitem "copy carries the warp" begin
+    using NamedTrajectories
+
+    traj = NamedTrajectory(
+        (x = randn(3, 5), u = randn(2, 5), Δt = fill(0.1, 1, 5));
+        controls = :u,
+        warp = GlobalScale(5.0),
+        global_data = [1.0],
+        global_components = (g = 1:1,),
+    )
+    c = copy(traj)
+    @test c.warp === traj.warp
+    @test vec(c) == vec(traj)
+    @test length(c) == length(traj)
+end
+
+@testitem "get_derived_names: role-based, not name-based" begin
+    using NamedTrajectories
+
+    plain = NamedTrajectory((x = randn(3, 5), z = fill(0.1, 1, 5)); timestep = :z)
+    @test get_derived_names(plain) == ()
+
+    warped = NamedTrajectory(
+        (x = randn(3, 5), z = fill(0.1, 1, 5), Δt = fill(0.2, 1, 5));
+        timestep = :z,
+        warp = GlobalScale(5.0),
+    )
+    # the TIMESTEP is derived under a warp — not "the component named Δt"
+    @test get_derived_names(warped) == (:z,)
+end
+
+@testitem "sync_timesteps! is the single writer of the derived rows" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = w,
+    )
+
+    # scribble over the derived rows, then sync restores them exactly
+    traj.data[traj.components.Δt, :] .= 999.0
+    @test sync_timesteps!(traj) === traj
+    @test traj.Δt == reshape(deltats_row(w, N), 1, N)
+
+    # no-op (returns the trajectory) without a warp
+    plain = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+    )
+    @test sync_timesteps!(plain) === plain
+    @test plain.Δt == fill(0.1, 1, N)
 end
 
 @testitem "isequal mismatch branches" begin

--- a/src/methods_named_trajectory.jl
+++ b/src/methods_named_trajectory.jl
@@ -319,6 +319,7 @@ function remove_components(
         initial = NamedTuple(k => v for (k, v) in pairs(traj.initial) if k ∉ names),
         final = NamedTuple(k => v for (k, v) in pairs(traj.final) if k ∉ names),
         goal = NamedTuple(k => v for (k, v) in pairs(traj.goal) if k ∉ names),
+        warp = traj.warp,
     )
 end
 
@@ -345,9 +346,22 @@ end
 Update the trajectory with a new datavec.
 
 Keyword arguments:
-    - `type::Symbol`: The type of the datavec, can be `:data`, `:global`, or `:both`. Default is `global`.
+    - `type::Symbol`: The type of the datavec, can be `:data`, `:global`, or `:both`. Default is global.
+
+Under a time warp the packed vector (the layout of `vec(traj)`) must go through
+`unpack!` instead — the derived timestep rows are never decision data — so `update!`
+with `type = :data` or `:both` throws `ArgumentError`; `type = :global` still works.
 """
 function update!(traj::NamedTrajectory, datavec::AbstractVector{<:Real}; type = :data)
+    if traj.warp !== nothing && type != :global
+        throw(
+            ArgumentError(
+                "update! with a packed vector is not supported under a warp — " *
+                "the timestep rows are derived, never decision data. " *
+                "Use unpack!(traj, z) with the packed layout of vec(traj).",
+            ),
+        )
+    end
     if type == :data
         traj.datavec[:] = datavec
     elseif type == :global
@@ -389,6 +403,9 @@ Merge names are used to specify which components to merge by index. If no merge 
 # Keyword Arguments
 - `timestep::Symbol`: The timestep symbol to use for free time problems. Default to the last trajectory.
 - `merge_names::Union{Nothing, NamedTuple{<:Any, <:Tuple{Vararg{Int}}}}=nothing`: The names to merge by index.
+
+Trajectories carrying a time warp cannot be merged (the warp is structural to its
+trajectory); merging them throws `ArgumentError`.
 """
 function Base.merge(traj1::NamedTrajectory, traj2::NamedTrajectory; kwargs...)
     return merge([traj1, traj2]; kwargs...)
@@ -402,6 +419,15 @@ function Base.merge(
 )
     if length(trajs) < 2
         throw(ArgumentError("At least two trajectories must be provided"))
+    end
+
+    # a warp is structural to its trajectory — merging is out of scope for v1
+    for (i, t) in enumerate(trajs)
+        t.warp === nothing || throw(
+            ArgumentError(
+                "merging trajectories with a warp is not supported (trajectory $i has a warp)",
+            ),
+        )
     end
 
     # organize names to drop by trajectory index
@@ -561,6 +587,7 @@ function add_suffix(traj::NamedTrajectory, suffix::String)
         initial = add_suffix(traj.initial, suffix),
         final = add_suffix(traj.final, suffix),
         goal = add_suffix(traj.goal, suffix),
+        warp = traj.warp,
     )
 end
 
@@ -665,6 +692,7 @@ function get_suffix(
         initial = get_suffix(traj.initial, suffix, remove = remove),
         final = get_suffix(traj.final, suffix, remove = remove),
         goal = get_suffix(traj.goal, suffix, remove = remove),
+        warp = traj.warp,
     )
 end
 
@@ -843,6 +871,7 @@ function add_control_derivatives(
         initial = new_initial,
         final = new_final,
         goal = traj.goal,
+        warp = traj.warp,
     )
 end
 
@@ -1503,6 +1532,115 @@ end
     @test_throws ArgumentError mk(bounds = (x = (randn(3), randn(2)),))
     # non-bound payload type hits the descriptive ArgumentError, not a TypeError
     @test_throws ArgumentError mk(bounds = (x = "not a bound",))
+end
+
+# =========================================================================== #
+#                      Derived timesteps — method surface                     #
+# =========================================================================== #
+
+@testitem "get_times and get_duration stay consistent with the warp" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = w,
+    )
+
+    @test get_times(traj) ≈ knot_times(w, N)
+    @test get_duration(traj) ≈ duration(w)
+    @test get_timesteps(traj) == vec(traj.Δt)
+
+    # a perturbed-T unpack moves the Δt rows and get_times coherently
+    z2 = copy(vec(traj))
+    z2[end] = 7.5
+    unpack!(traj, z2)
+    @test traj.Δt == reshape(deltats_row(GlobalScale(7.5), N), 1, N)
+    @test get_times(traj) ≈ knot_times(GlobalScale(7.5), N)
+    @test get_duration(traj) ≈ 7.5
+end
+
+@testitem "update! with a packed vector throws under a warp" begin
+    using NamedTrajectories
+
+    traj = NamedTrajectory(
+        (x = randn(3, 5), u = randn(2, 5), Δt = fill(0.1, 1, 5));
+        controls = :u,
+        warp = GlobalScale(5.0),
+        global_data = [1.0, 2.0],
+        global_components = (g = 1:2,),
+    )
+
+    # packed vectors go through unpack!, not update!
+    @test_throws ArgumentError update!(traj, vec(traj))
+    @test_throws ArgumentError update!(traj, randn(length(traj) - 2); type = :both)
+
+    # globals are untouched by the warp: update!(type = :global) still works
+    update!(traj, [7.0, 8.0]; type = :global)
+    @test traj.global_data == [7.0, 8.0]
+end
+
+@testitem "add_control_derivatives preserves the warp" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = w,
+    )
+
+    traj_d = add_control_derivatives(traj, 1; control_name = :u)
+    @test traj_d.warp === traj.warp
+    @test :du ∈ traj_d.control_names
+    @test traj_d.Δt == reshape(deltats_row(w, N), 1, N)
+    @test length(traj_d) == (traj_d.dim - 1) * N + n_params(w)
+    @test get_times(traj_d) ≈ knot_times(w, N)
+end
+
+@testitem "merge rejects warped trajectories" begin
+    using NamedTrajectories
+
+    N = 5
+    plain = NamedTrajectory(randn(5, N), (x = 1:3, y = 4:4, z = 5:5); timestep = :z)
+    warped = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = GlobalScale(5.0),
+    )
+    @test_throws ArgumentError merge([plain, warped])
+    @test_throws ArgumentError merge([warped, plain])
+end
+
+@testitem "component and suffix operations preserve the warp" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        warp = w,
+    )
+
+    # add / remove component
+    traj_y = add_component(traj, :y, randn(N))
+    @test traj_y.warp === traj.warp
+    @test get_times(traj_y) ≈ knot_times(w, N)
+    traj_rm = remove_component(traj_y, :y)
+    @test traj_rm.warp === traj.warp
+
+    # algebraic methods
+    @test (2.0 * traj).warp === traj.warp
+
+    # suffix
+    traj_s = add_suffix(traj, "_1")
+    @test traj_s.warp === traj.warp
+    @test traj_s.timestep == :Δt_1
+    @test get_times(traj_s) ≈ knot_times(w, N)
 end
 
 end

--- a/src/struct_named_trajectory.jl
+++ b/src/struct_named_trajectory.jl
@@ -5,6 +5,8 @@ export NamedTrajectory
 using OrderedCollections
 using TestItems
 
+using ..TimeWarp: AbstractTimeWarp, deltats_row, is_monotone
+
 # ---------------------------------------------------------------------------- #
 # Types for NamedTrajectory
 # ---------------------------------------------------------------------------- #
@@ -80,6 +82,10 @@ mutable struct NamedTrajectory{
     global_dims::NamedTuple{GDNames,GDTypes}
     global_components::NamedTuple{GCNames,GCTypes}
     global_names::GN
+    # Optional time warp. When `warp !== nothing` the timestep component is DERIVED:
+    # present as rows (every consumer keeps working) but excluded from the packed
+    # decision vector, and rewritten from `(warp, N)` by `sync_timesteps!`.
+    warp::Union{Nothing,AbstractTimeWarp}
 end
 
 """
@@ -99,6 +105,7 @@ function NamedTrajectory(
     goal = NamedTuple(),
     global_data::AbstractVector{R} = R[],
     global_components::NamedTuple{GN,<:ComponentType} where {GN} = NamedTuple(),
+    warp::Union{Nothing,AbstractTimeWarp} = nothing,
 ) where {R<:Real}
     @assert :data ∉ keys(comps) "data is a reserved name"
     @assert isdisjoint(keys(comps), keys(global_components)) "components and global components should use unique names"
@@ -121,6 +128,25 @@ function NamedTrajectory(
     dims = NamedTuple(dims_pairs)
     dim = sum(values(dims), init = 0)
     @assert dim * N == length(datavec) "Data vector length does not match components"
+
+    # derived timesteps: under a warp the timestep rows are rewritten from
+    # (warp, N) — passed-in timestep values are ignored. Own the buffer first
+    # so a caller-held datavec is never mutated.
+    if warp !== nothing
+        dims[timestep] == 1 || throw(
+            ArgumentError(
+                "a derived timestep row must be single-row (dims[:$timestep] = $(dims[timestep]))",
+            ),
+        )
+        is_monotone(warp, N) || throw(
+            ArgumentError(
+                "warp is not monotone on the $N-knot lattice — derived timesteps must be positive",
+            ),
+        )
+        datavec = Vector{R}(datavec)
+        data = reshape(datavec, dim, N)
+        data[comps[timestep], :] .= reshape(deltats_row(warp, N), 1, :)
+    end
 
     # process and save bounds
     bounds = get_bounds_from_dims(bounds, dims, dtype = R)
@@ -155,6 +181,7 @@ function NamedTrajectory(
         global_dims,
         global_components,
         global_names,
+        warp,
     )
 end
 
@@ -259,6 +286,7 @@ function NamedTrajectory(
     goal = traj.goal,
     global_data::AbstractVector{R} = traj.global_data,
     global_components::NamedTuple{GN,<:ComponentType} where {GN} = traj.global_components,
+    warp::Union{Nothing,AbstractTimeWarp} = traj.warp,
 ) where {R<:Real}
     @assert length(datavec) == sum(length.(values(components)), init = 0) * N "Data vector length does not match components * N"
     @assert length(global_data) == sum(length.(values(global_components)), init = 0) "Global data length does not match global components"
@@ -283,6 +311,7 @@ function NamedTrajectory(
         goal = goal,
         global_data = global_data_concrete,
         global_components = global_components,
+        warp = warp,
     )
 end
 
@@ -531,6 +560,73 @@ end
     # Test 3: Values should match regardless of input type
     @test traj1.x == base_traj.x
     @test traj2.x == base_traj.x
+end
+
+@testitem "construct with a warp derives the timestep rows" begin
+    using NamedTrajectories
+
+    N = 10
+    w = GlobalScale(5.0)  # L = 9
+
+    # the passed timestep values are overwritten from the warp at construction
+    traj = NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N));
+        controls = :u,
+        timestep = :Δt,
+        warp = w,
+    )
+    @test traj.Δt == reshape(deltats_row(w, N), 1, N)
+    @test [traj.datavec[first(traj.components.Δt)+(k-1)*traj.dim] for k = 1:N] == collect(deltats_row(w, N))
+
+    # roles unchanged: the derived row is still the timestep and still a control
+    @test traj.timestep == :Δt
+    @test :Δt ∈ traj.control_names
+    @test traj.names == (:x, :u, :Δt)
+    @test traj.dim == 6
+    @test traj.dims.Δt == 1
+
+    # non-Δt data untouched
+    @test traj.x == traj.data[traj.components.x, :]
+
+    # the show method marks the derived row
+    @test occursin("⇒ Δt", sprint(show, traj))
+
+    # the copy-constructor preserves the warp
+    @test NamedTrajectory(traj).warp === traj.warp
+end
+
+@testitem "warp construction validates monotonicity, row count, and type" begin
+    using NamedTrajectories
+
+    N = 10
+    data = (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 1, N))
+
+    # a warp must be monotone on the lattice — derived Δt must be positive
+    @test_throws ArgumentError NamedTrajectory(data; warp = GlobalScale(0.0))
+    @test_throws ArgumentError NamedTrajectory(data; warp = GlobalScale(-1.0))
+
+    # the derived timestep row must be single-row
+    @test_throws ArgumentError NamedTrajectory(
+        (x = randn(3, N), u = randn(2, N), Δt = fill(0.1, 2, N));
+        timestep = :Δt,
+        warp = GlobalScale(5.0),
+    )
+
+    # the lattice needs at least 2 knots
+    @test_throws ArgumentError NamedTrajectory(
+        (x = randn(3, 1), u = randn(2, 1), Δt = fill(0.1, 1, 1));
+        warp = GlobalScale(5.0),
+    )
+
+    # the warp must be an AbstractTimeWarp (typed keyword → TypeError)
+    @test_throws TypeError NamedTrajectory(data; warp = 5.0)
+end
+
+@testitem "explicit warp = nothing constructs identically to the default" begin
+    using NamedTrajectories
+
+    data = (x = randn(3, 5), u = randn(2, 5), Δt = fill(0.1, 1, 5))
+    @test NamedTrajectory(data; warp = nothing) == NamedTrajectory(data)
 end
 
 end

--- a/src/time_warp.jl
+++ b/src/time_warp.jl
@@ -1,0 +1,275 @@
+module TimeWarp
+
+using ForwardDiff
+using TestItems
+
+export AbstractTimeWarp, GlobalScale, PiecewiseLinearWarp
+export warp_params, n_params, with_params
+export deltats, deltats_row, knot_times, duration, is_monotone
+export ddeltats_dparams
+
+# ---------------------------------------------------------------------------- #
+# AbstractTimeWarp — monotone time warps on the normalized knot lattice
+# ---------------------------------------------------------------------------- #
+
+"""
+    AbstractTimeWarp
+
+A monotone time warp `w : [0,1] → [0, T]` applied to the normalized coordinates of a
+trajectory's uniform knot lattice (`N` knots at `sₖ = (k-1)/(N-1)`). Under a warp, a
+`NamedTrajectory`'s timestep rows are **derived** — `Δtₖ = w(sₖ₊₁) - w(sₖ)` — and are
+never decision data: they stay present as components but are excluded from the packed
+vector (see `NamedTrajectory(...; warp = ...)`).
+
+Interface contract for a concrete warp `W <: AbstractTimeWarp`:
+
+  - `(w::W)(s::Real)::Real` — monotone; must accept `ForwardDiff.Dual` in `s` *and* in params;
+  - `warp_params(w)::AbstractVector` — current parameter values (may be empty);
+  - `n_params(w)::Int`;
+  - `with_params(w, θ)::AbstractTimeWarp` — Dual-generic rebuild (the AD seam);
+  - `duration(w)::Real` — `== w(1) - w(0)`.
+
+`deltats`, `deltats_row`, `knot_times`, `is_monotone` and `ddeltats_dparams` are derived
+generically from that contract.
+"""
+abstract type AbstractTimeWarp end
+
+_check_lattice(N::Int) =
+    N ≥ 2 || throw(ArgumentError("a time warp needs at least 2 knots (got N = $N)"))
+
+"""
+    deltats(w, N::Int)::Vector
+
+Physical duration of each of the `N - 1` lattice intervals under the time warp `w`:
+`deltats(w, N)[k] = w(k/(N-1)) - w((k-1)/(N-1))`. Generic over `w`'s parameter types
+(`Float64`, `ForwardDiff.Dual`, …).
+"""
+function deltats(w, N::Int)
+    _check_lattice(N)
+    L = N - 1
+    return [w(k / L) - w((k - 1) / L) for k = 1:L]
+end
+
+"""
+    deltats_row(w, N::Int)::Vector
+
+The derived timestep row of length `N`: [`deltats`](@ref) padded with its final value —
+the Piccolo convention (`get_times` consumes only the first `N - 1` entries).
+"""
+function deltats_row(w, N::Int)
+    dts = deltats(w, N)
+    return [dts; dts[end]]
+end
+
+"""
+    knot_times(w, N::Int)::Vector
+
+Physical times of the `N` lattice knots under the time warp `w`:
+`knot_times(w, N)[k] = w((k-1)/(N-1))`. Consistent with `get_times` on a trajectory
+whose timestep rows are derived from `w`.
+"""
+function knot_times(w, N::Int)
+    _check_lattice(N)
+    L = N - 1
+    return [w((k - 1) / L) for k = 1:N]
+end
+
+"""
+    duration(w::AbstractTimeWarp)::Real
+
+Total physical duration of the warp: `w(1) - w(0)`.
+"""
+duration(w::AbstractTimeWarp) = w(1.0) - w(0.0)
+
+"""
+    is_monotone(w, N::Int)::Bool
+
+Monotonicity of the time warp `w` over the `N`-knot lattice — sufficient (and necessary,
+for a continuous warp) for all derived timesteps to be positive.
+"""
+is_monotone(w, N::Int) = all(>(0), deltats(w, N))
+
+"""
+    ddeltats_dparams(w, N::Int)::Matrix
+
+Chain rule `∂Δtₖ/∂θⱼ` as an `(N - 1) × n_params(w)` matrix, where `θ` are the warp
+parameters ([`warp_params`](@ref)). The generic implementation differentiates
+[`deltats`](@ref) through [`with_params`](@ref) with ForwardDiff; concrete warps may
+override it exactly (as `GlobalScale` does — no floating subtraction).
+"""
+function ddeltats_dparams(w, N::Int)
+    return ForwardDiff.jacobian(θ -> deltats(with_params(w, θ), N), warp_params(w))
+end
+
+# ---- GlobalScale: w(s) = T·s — the single-scalar warp (v1) ------------------- #
+
+"""
+    GlobalScale(T)
+
+Global time scaling `w(s) = T·s`. `T` is the single warp parameter — the total
+duration, and (downstream) the scalar decision variable that replaces the per-knot
+`Δt` block of a free-time formulation. Parametric in `R` so that `with_params` under
+ForwardDiff produces a `Dual`-typed warp. The derived timesteps are
+`Δtₖ = T·wₖ` with the **exact rational** lattice weights `wₖ = 1/(N-1)`;
+[`ddeltats_dparams`](@ref) exposes `∂Δtₖ/∂T = wₖ` exactly.
+"""
+struct GlobalScale{R<:Real} <: AbstractTimeWarp
+    T::R
+end
+
+(w::GlobalScale)(s::Real) = w.T * s
+
+warp_params(w::GlobalScale) = [w.T]
+n_params(::GlobalScale) = 1
+with_params(::GlobalScale, θ::AbstractVector{<:Real}) = GlobalScale(θ[1])
+duration(w::GlobalScale) = w.T
+
+# Exact: dΔtₖ/dT is the interval's lattice fraction 1/(N-1) — no floating subtraction.
+function ddeltats_dparams(w::GlobalScale, N::Int)
+    _check_lattice(N)
+    return reshape(fill(Float64(1 // (N - 1)), N - 1), :, 1)
+end
+
+# ---- PiecewiseLinearWarp: interface-complete, NOT NLP-wired (v1) -------------- #
+
+"""
+    PiecewiseLinearWarp(anchors, durations)
+
+Piecewise-linear monotone warp: `anchors` are exact normalized breakpoints
+`0 = a₁ < … < a_K = 1` (`Rational{Int}`, on the lattice), and `durations[j] > 0` is the
+physical duration of `[aⱼ, aⱼ₊₁]`. The parameters are the `durations`; positivity makes
+the warp monotone. Interface-tested in v1 but **not wired** into the packed-vector
+optimization flow.
+"""
+struct PiecewiseLinearWarp{R<:Real} <: AbstractTimeWarp
+    anchors::Vector{Rational{Int}}
+    durations::Vector{R}
+
+    function PiecewiseLinearWarp(
+        anchors::AbstractVector{<:Rational{<:Integer}},
+        durations::AbstractVector{R},
+    ) where {R<:Real}
+        length(anchors) ≥ 2 || throw(ArgumentError("need at least 2 anchors"))
+        first(anchors) == 0 || throw(ArgumentError("first anchor must be 0"))
+        last(anchors) == 1 || throw(ArgumentError("last anchor must be 1"))
+        for j = 1:(length(anchors)-1)
+            anchors[j] < anchors[j+1] ||
+                throw(ArgumentError("anchors must be strictly increasing at index $j"))
+        end
+        length(durations) == length(anchors) - 1 ||
+            throw(ArgumentError("need length(durations) == length(anchors) - 1"))
+        return new{R}(Vector{Rational{Int}}(anchors), Vector{R}(durations))
+    end
+end
+
+function (w::PiecewiseLinearWarp)(s::Real)
+    a = w.anchors
+    j = clamp(searchsortedlast(a, s), 1, length(a) - 1)
+    t = sum(view(w.durations, 1:(j-1)); init = zero(eltype(w.durations)))
+    return t + w.durations[j] * ((s - a[j]) / (a[j+1] - a[j]))
+end
+
+warp_params(w::PiecewiseLinearWarp) = collect(w.durations)
+n_params(w::PiecewiseLinearWarp) = length(w.durations)
+with_params(w::PiecewiseLinearWarp, θ::AbstractVector{<:Real}) =
+    PiecewiseLinearWarp(w.anchors, θ)
+duration(w::PiecewiseLinearWarp) = sum(w.durations)
+
+# =========================================================================== #
+
+@testitem "GlobalScale: exact lattice weights and chain-rule override" begin
+    using NamedTrajectories
+    import ForwardDiff
+
+    w = GlobalScale(7.5)
+    N = 13  # L = 12 intervals
+
+    @test duration(w) == 7.5
+    @test knot_times(w, N) ≈ 7.5 .* (0:12) ./ 12
+    @test deltats(w, N) ≈ fill(7.5 / 12, 12)
+    @test sum(deltats(w, N)) ≈ duration(w)
+    @test is_monotone(w, N)
+    @test !is_monotone(GlobalScale(0.0), N)
+    @test !is_monotone(GlobalScale(-1.0), N)
+
+    # the padded row: length N, first N-1 entries are the interval durations
+    row = deltats_row(w, N)
+    @test length(row) == N
+    @test row[1:(end-1)] == deltats(w, N)
+    @test row[end] == row[end-1]
+
+    # Exact override: the column IS the rational lattice weights — exact ==, never ≈.
+    J = ddeltats_dparams(w, N)
+    @test size(J) == (12, 1)
+    @test J[:, 1] == Float64.(fill(1 // 12, 12))
+
+    # Agreement with the generic ForwardDiff path (invoked explicitly).
+    J_fd = ForwardDiff.jacobian(θ -> deltats(with_params(w, θ), N), warp_params(w))
+    @test J ≈ J_fd
+
+    # AD seam: T flows through with_params as a Dual.
+    @test ForwardDiff.derivative(T -> GlobalScale(T)(0.4), 2.0) ≈ 0.4
+    @test warp_params(with_params(w, [3.25])) == [3.25]
+    @test n_params(w) == 1
+end
+
+@testitem "PiecewiseLinearWarp interface contract" begin
+    using NamedTrajectories
+    import ForwardDiff
+
+    anchors = [0 // 1, 1 // 3, 1 // 2, 1 // 1]
+    w = PiecewiseLinearWarp(anchors, [1.0, 2.0, 3.0])
+
+    # Evaluation: exact at anchors, linear between.
+    @test w(0.0) == 0.0
+    @test w(1 / 3) ≈ 1.0
+    @test w(1 / 2) ≈ 3.0
+    @test w(1.0) ≈ 6.0
+    @test w(1 / 6) ≈ 0.5
+    @test w(0.75) ≈ 4.5
+    @test duration(w) ≈ 6.0
+
+    # Derived Δt on an anchor-aligned lattice (L = 6 ⇒ N = 7 knots):
+    # [0,1/3] → 1.0, [1/3,1/2] → 2.0, [1/2,1] → 3.0.
+    @test deltats(w, 7) ≈ [0.5, 0.5, 2.0, 1.0, 1.0, 1.0]
+    @test sum(deltats(w, 7)) ≈ duration(w)
+    @test knot_times(w, 7) ≈ [0.0, 0.5, 1.0, 3.0, 4.0, 5.0, 6.0]
+    @test is_monotone(w, 7)
+    @test !is_monotone(PiecewiseLinearWarp(anchors, [1.0, -2.0, 3.0]), 7)
+
+    # Chain rule via the generic ForwardDiff path, checked against hand-computed rows:
+    # [0,1/3] splits into two intervals of weight 1/2; [1/3,1/2] is ONE interval
+    # covering the whole segment, so ∂Δt₃/∂θ₂ = 1; [1/2,1] spans three intervals
+    # of lattice fraction 1/3, so each carries ∂Δt/∂θ₃ = 1/3.
+    @test ddeltats_dparams(w, 7) ≈
+          [0.5 0.0 0.0; 0.5 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1/3; 0.0 0.0 1/3; 0.0 0.0 1/3]
+
+    # Params round-trip + Dual-genericity of the rebuild.
+    @test warp_params(w) == [1.0, 2.0, 3.0]
+    @test n_params(w) == 3
+    @test warp_params(with_params(w, [4.0, 5.0, 6.0])) == [4.0, 5.0, 6.0]
+    grad = ForwardDiff.gradient(θ -> with_params(w, θ)(0.75), warp_params(w))
+    @test grad ≈ [1.0, 1.0, 0.5]
+
+    # Constructor validation.
+    @test_throws ArgumentError PiecewiseLinearWarp([0 // 1, 1 // 2], [1.0, 1.0]) # length mismatch
+    @test_throws ArgumentError PiecewiseLinearWarp([1 // 3, 1 // 1], [1.0])      # first ≠ 0
+    @test_throws ArgumentError PiecewiseLinearWarp([0 // 1, 1 // 2], [1.0])      # last ≠ 1
+    @test_throws ArgumentError PiecewiseLinearWarp(
+        [0 // 1, 1 // 2, 1 // 3, 1 // 1],
+        [1.0, 1.0, 1.0],
+    )                                                                             # not increasing
+end
+
+@testitem "warp lattice functions validate N ≥ 2" begin
+    using NamedTrajectories
+
+    w = GlobalScale(1.0)
+    @test_throws ArgumentError deltats(w, 1)
+    @test_throws ArgumentError deltats_row(w, 1)
+    @test_throws ArgumentError knot_times(w, 1)
+    @test_throws ArgumentError is_monotone(w, 1)
+    @test_throws ArgumentError ddeltats_dparams(w, 1)
+end
+
+end


### PR DESCRIPTION
Closes #160.

## What

Adds an optional **time warp** to `NamedTrajectory` (`warp = GlobalScale(T0)`). Under a warp the timestep rows become **derived**: present as components — `get_times`, plotting, rollouts all keep working unchanged — but excluded from the packed decision vector. `warp = nothing` (the default) is bit-identical to the historical accounting.

## New public API (`src/time_warp.jl`)

- `AbstractTimeWarp` interface: call `w(s)` (Dual-generic), `warp_params`, `n_params`, `with_params` (the AD seam), `duration`; derived generics `deltats`, `deltats_row`, `knot_times`, `is_monotone`.
- `GlobalScale(T)`: `w(s) = T·s` — `Δtₖ = T·wₖ` with exact rational lattice weights `wₖ = 1/(N-1)`; `ddeltats_dparams` overridden exactly (`∂Δtₖ/∂T = wₖ`, no floating subtraction).
- `PiecewiseLinearWarp`: interface-tested, **not** NLP-wired (as scoped).

## Behavior under a warp

- Construction validates monotonicity + single-row timestep and rewrites the Δt rows from `(warp, N)`.
- `vec(traj)` / `length(traj)`: per-knot non-derived rows, then globals, then the trailing warp params (the scalar `T` — the decision variable that replaces the per-knot Δt block).
- `unpack!(traj, z)`: writes non-derived components only, rebuilds the warp via `with_params`, then `sync_timesteps!` re-derives the rows — the single writer. `update!` with a packed vector throws under a warp.
- Exclusion from the packed vector is by component **role** (`get_derived_names`), never by name.
- Merging warped trajectories throws (structural, not user data — v1 scope).

## Key decisions honored (from #160)

- Warp lives INSIDE `NamedTrajectory` (no wrapper type; no dual-grid split — later track).
- Warp params in a dedicated field, never in `global_data`.
- Reference oracle: GriddedDiscretization.jl `src/time_warp.jl` + sync pattern (PLAN §5.2/§5.4).

## Tests

New testitems: warp interface (GlobalScale exact weights + chain-rule override + FD agreement; PiecewiseLinearWarp contract incl. Dual-generic rebuild; lattice validation), construction/derivation (exact `==` rows, overwrite, validation), packed vec/length accounting, unpack! roundtrip + perturbed-T coherence, copy/derived-names/sync single-writer, get_times coherence, update!/merge/derivatives/suffix/component ecosystem. **Full suite: 489 passed / 0 failed** (Aqua + JET + all testitems, Julia 1.12.5); JuliaFormatter applied per the Formatter CI.