### PR TITLE
release: v0.9.4 — the warp release (derived timestep rows via GlobalScale)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to NamedTrajectories.jl are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the package
 follows Julia 0.x SemVer.
 
-## [Unreleased]
+## [0.9.4]
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NamedTrajectories"
 uuid = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Additive feature release (0.9.3 → 0.9.4): NamedTrajectories#160/#161 (optional time warp — AbstractTimeWarp, GlobalScale v1, sync_timesteps!, derived Δt rows), the Julia 1.12 compat floor (#158), KnotPoint setindex! fix, and 100% line coverage work since 0.9.3.

Unblocks the stack's NT@main [sources] floats (DTO #150's warp plumbing, Piccolissimo 3b): consumers re-pin to the version at their next releases (A4 of the piccolo-stack program). Additive — no breaking-note requirement.